### PR TITLE
Use Gradualizer with form check timeouts

### DIFF
--- a/lib/gradient/elixir_fmt.ex
+++ b/lib/gradient/elixir_fmt.ex
@@ -101,7 +101,7 @@ defmodule Gradient.ElixirFmt do
     module = "#{inspect(module)}"
 
     :io_lib.format(
-      "~sUndefined ~s ~s:~p/~p~s~n",
+      "~sUndefined ~s ~s.~p/~p~s~n",
       [
         format_location(anno, :brief, opts),
         type,

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule Gradient.MixProject do
   # Run "mix help deps" to learn about dependencies.
   def deps do
     [
-      {:gradualizer, github: "josefs/Gradualizer", ref: "master", manager: :rebar3},
+      {:gradualizer, github: "erszcz/Gradualizer", ref: "gradient", manager: :rebar3},
       # {:gradualizer, path: "../Gradualizer/", manager: :rebar3},
       {:dialyxir, "~> 1.0", only: [:dev], runtime: false}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
   "dialyxir": {:hex, :dialyxir, "1.1.0", "c5aab0d6e71e5522e77beff7ba9e08f8e02bad90dfbeffae60eaf0cb47e29488", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "07ea8e49c45f15264ebe6d5b93799d4dd56a44036cf42d0ad9c960bc266c0b9a"},
   "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
-  "gradualizer": {:git, "https://github.com/josefs/Gradualizer.git", "051040400924dfcfe59f7a8936beb34b43278191", [ref: "master"]}
+  "gradualizer": {:git, "https://github.com/erszcz/Gradualizer.git", "650998de4e69f702a9d6d6918b2911c174430e81", [ref: "gradient"]},
 }


### PR DESCRIPTION
This addresses running Gradient in the project from #38. Specifically, without timeouts on form checks Gradient (Gradualizer) gets stuck on `mix gradient`, never terminates, and makes the machine spin its fans like crazy. With form check timeouts some forms are just reported as timing out, therefore marking where Gradient needs improvement.