### PR TITLE
Make ElixirFmt colors configurable and improve formatting

### DIFF
--- a/lib/gradient/elixir_expr.ex
+++ b/lib/gradient/elixir_expr.ex
@@ -35,7 +35,7 @@ defmodule Gradient.ElixirExpr do
   def pp_expr({:atom, _, val}) do
     case Atom.to_string(val) do
       "Elixir." <> mod -> mod
-      str -> ":" <> str
+      str -> ":\"" <> str <> "\""
     end
   end
 
@@ -420,7 +420,7 @@ defmodule Gradient.ElixirExpr do
 
     if shortand_syntax do
       {:atom, _, key} = key
-      Atom.to_string(key) <> ": " <> value
+      "\"" <> Atom.to_string(key) <> "\": " <> value
     else
       pp_expr(key) <> " => " <> value
     end

--- a/lib/gradient/elixir_expr.ex
+++ b/lib/gradient/elixir_expr.ex
@@ -11,7 +11,7 @@ defmodule Gradient.ElixirExpr do
   @doc """
   Convert abstract expressions to Elixir code and format output with formatter.
   """
-  @spec pp_expr_format([expr()], keyword()) :: iodata()
+  @spec pp_expr_format(expr() | [expr()], keyword()) :: iodata()
   def pp_expr_format(exprs, fmt_opts \\ []) do
     exprs
     |> pp_expr()

--- a/lib/gradient/elixir_type.ex
+++ b/lib/gradient/elixir_type.ex
@@ -1,16 +1,21 @@
 defmodule Gradient.ElixirType do
   @moduledoc """
-  Module to format types.
-
-  Seems that:
-  - record type
-  - constrained function type
-  are not used by Elixir so the pp support has not been added.
+  Convert the Erlang abstract types to the Elixir code.
   """
 
   alias Gradient.ElixirFmt
 
   @type abstract_type() :: Gradient.Types.abstract_type()
+
+  @doc """
+  Convert abstract type to Elixir code and format output with formatter.
+  """
+  @spec pp_type_format(abstract_type(), keyword()) :: iodata()
+  def pp_type_format(type, fmt_opts \\ []) do
+    type
+    |> pretty_print()
+    |> Code.format_string!(fmt_opts)
+  end
 
   @doc """
   Take type and prepare a pretty string representation.

--- a/lib/gradient/elixir_type.ex
+++ b/lib/gradient/elixir_type.ex
@@ -84,7 +84,10 @@ defmodule Gradient.ElixirType do
   end
 
   def pretty_print({:atom, _, val}) do
-    ":" <> Atom.to_string(val)
+    case Atom.to_string(val) do
+      "Elixir." <> mod -> mod
+      str -> ":\"" <> str <> "\""
+    end
   end
 
   def pretty_print({:integer, _, val}) do

--- a/lib/gradient/types.ex
+++ b/lib/gradient/types.ex
@@ -2,6 +2,7 @@ defmodule Gradient.Types do
   @type token :: tuple()
   @type tokens :: [tuple()]
   @type abstract_type :: :erl_parse.abstract_type()
+  @type abstract_expr :: :erl_parse.abstract_expr()
   @type form ::
           :erl_parse.abstract_clause()
           | :erl_parse.abstract_expr()

--- a/test/gradient/elixir_expr_test.exs
+++ b/test/gradient/elixir_expr_test.exs
@@ -45,7 +45,7 @@ defmodule Gradient.ElixirExprTest do
         end
         |> ElixirExpr.pp_expr()
 
-      assert "fn {:ok, v} -> v; {:error, _} -> :error end" == actual
+      assert ~s(fn {:"ok", v} -> v; {:"error", _} -> :"error" end) == actual
     end
 
     test "binary comprehension" do
@@ -79,7 +79,7 @@ defmodule Gradient.ElixirExprTest do
         end
         |> ElixirExpr.pp_expr()
 
-      assert "receive do {:hello, msg} -> msg end" == actual
+      assert ~s(receive do {:"hello", msg} -> msg end) == actual
     end
 
     test "receive after" do
@@ -93,7 +93,7 @@ defmodule Gradient.ElixirExprTest do
         end
         |> ElixirExpr.pp_expr()
 
-      assert ~s(receive do {:hello, msg} -> msg after 1000 -> "nothing happened" end) == actual
+      assert ~s(receive do {:"hello", msg} -> msg after 1000 -> "nothing happened" end) == actual
     end
 
     test "call pipe" do
@@ -123,7 +123,7 @@ defmodule Gradient.ElixirExprTest do
         end
         |> ElixirExpr.pp_expr()
 
-      assert "map = %{a: 12, b: 0}; case :maps.find(:a, map) do {:ok, a} -> case :maps.find(:b, map) do {:ok, b} -> a + b; _gen -> case _gen do :error -> 0; _gen -> raise {:with_clause, _gen} end end; _gen -> case _gen do :error -> 0; _gen -> raise {:with_clause, _gen} end end" ==
+      assert ~s(map = %{"a": 12, "b": 0}; case :maps.find(:"a", map\) do {:"ok", a} -> case :maps.find(:"b", map\) do {:"ok", b} -> a + b; _gen -> case _gen do :"error" -> 0; _gen -> raise {:"with_clause", _gen} end end; _gen -> case _gen do :"error" -> 0; _gen -> raise {:"with_clause", _gen} end end) ==
                actual
     end
 
@@ -140,7 +140,7 @@ defmodule Gradient.ElixirExprTest do
         end
         |> ElixirExpr.pp_expr()
 
-      assert ~s(try do raise "ok"; catch :error, e -> IO.puts(Exception.format(:error, e, __STACKTRACE__\)\); reraise e, __STACKTRACE__ end) ==
+      assert ~s(try do raise "ok"; catch :"error", e -> IO.puts(Exception.format(:"error", e, __STACKTRACE__\)\); reraise e, __STACKTRACE__ end) ==
                actual
     end
 
@@ -155,7 +155,7 @@ defmodule Gradient.ElixirExprTest do
         end
         |> ElixirExpr.pp_expr()
 
-      assert ~s(try do raise "oops"; catch :error, %RuntimeError{} = _ -> "Error!" end) ==
+      assert ~s(try do raise "oops"; catch :"error", %RuntimeError{} = _ -> "Error!" end) ==
                actual
     end
 
@@ -170,7 +170,7 @@ defmodule Gradient.ElixirExprTest do
         end
         |> ElixirExpr.pp_expr()
 
-      assert "try do :ok; catch :error, _ -> :ok end" == actual
+      assert ~s(try do :"ok"; catch :"error", _ -> :"ok" end) == actual
     end
 
     test "simple after try" do
@@ -184,7 +184,7 @@ defmodule Gradient.ElixirExprTest do
         end
         |> ElixirExpr.pp_expr()
 
-      assert "try do :ok; after :ok end" == actual
+      assert ~s(try do :"ok"; after :"ok" end) == actual
     end
 
     test "try guard" do
@@ -215,7 +215,7 @@ defmodule Gradient.ElixirExprTest do
         end
         |> ElixirExpr.pp_expr()
 
-      assert ~s(try do throw "good"; :ok; else v when v == :ok -> :ok; v -> :nok; catch :error, %RuntimeError{} = e -> 11; e; :throw, val -> val; :throw, _ -> 0; after IO.puts("Cleaning!"\) end) ==
+      assert ~s(try do throw "good"; :"ok"; else v when v == :"ok" -> :"ok"; v -> :"nok"; catch :"error", %RuntimeError{} = e -> 11; e; :"throw", val -> val; :"throw", _ -> 0; after IO.puts("Cleaning!"\) end) ==
                actual
     end
 
@@ -235,7 +235,7 @@ defmodule Gradient.ElixirExprTest do
         end
         |> ElixirExpr.pp_expr()
 
-      assert "case {:ok, 10} do {:ok, v} when v > 0 and v > 1 or v < - 1 -> :ok; t when :erlang.is_tuple(t) -> :nok; _ -> :err end" ==
+      assert ~s(case {:"ok", 10} do {:"ok", v} when v > 0 and v > 1 or v < - 1 -> :"ok"; t when :erlang.is_tuple(t\) -> :"nok"; _ -> :"err" end) ==
                actual
     end
 
@@ -249,7 +249,7 @@ defmodule Gradient.ElixirExprTest do
         end
         |> ElixirExpr.pp_expr()
 
-      assert "case {:ok, 13} do {:ok, v} -> v; _err -> :error end" == actual
+      assert ~s(case {:"ok", 13} do {:"ok", v} -> v; _err -> :"error" end) == actual
     end
 
     test "if" do
@@ -263,7 +263,7 @@ defmodule Gradient.ElixirExprTest do
         end
         |> ElixirExpr.pp_expr()
 
-      assert "if :math.floor(1.9) == 1.0 do :ok else :error end" == actual
+      assert ~s(if :math.floor(1.9\) == 1.0 do :"ok" else :"error" end) == actual
     end
 
     test "unless" do
@@ -277,7 +277,7 @@ defmodule Gradient.ElixirExprTest do
         end
         |> ElixirExpr.pp_expr()
 
-      assert "if :math.floor(1.9) == 1.0 do :error else :ok end" == actual
+      assert ~s(if :math.floor(1.9\) == 1.0 do :"error" else :"ok" end) == actual
     end
 
     test "cond" do
@@ -296,7 +296,7 @@ defmodule Gradient.ElixirExprTest do
         end
         |> ElixirExpr.pp_expr()
 
-      assert "cond do true == false -> :ok; :math.floor(1.9) == 1.0 -> :ok; true -> :error end" ==
+      assert ~s(cond do true == false -> :"ok"; :math.floor\(1.9\) == 1.0 -> :"ok"; true -> :"error" end) ==
                actual
     end
 
@@ -322,7 +322,7 @@ defmodule Gradient.ElixirExprTest do
         |> ElixirExpr.pp_expr()
 
       assert ~s(try do if true do throw "good" else raise "oops" end;) <>
-               ~s( catch :error, %RuntimeError{} = e -> 11; e; :throw, val -> 12; val end) ==
+               ~s( catch :"error", %RuntimeError{} = e -> 11; e; :"throw", val -> 12; val end) ==
                actual
     end
   end

--- a/test/gradient/elixir_fmt_test.exs
+++ b/test/gradient/elixir_fmt_test.exs
@@ -209,7 +209,7 @@ defmodule Gradient.ElixirFmtTest do
 
     test "string", %{wrong_ret_errors: errors} do
       expr = expr_format_error_to_binary(errors.ret_wrong_boolean2)
-      assert String.contains?(expr, "\"1234\"")
+      assert String.contains?(expr, ~s("1234"))
     end
 
     test "char", %{wrong_ret_errors: errors} do
@@ -225,7 +225,7 @@ defmodule Gradient.ElixirFmtTest do
 
     test "record", %{record_type_errors: errors} do
       expr = expr_format_error_to_binary(errors.ret_wrong_atom)
-      assert String.contains?(expr, "{:user, \"Kate\", 25}")
+      assert String.contains?(expr, ~s({:user, "Kate", 25}))
     end
 
     test "call", %{wrong_ret_errors: errors} do
@@ -270,8 +270,8 @@ defmodule Gradient.ElixirFmtTest do
   end
 
   defp expr_format_error_to_binary(error, opts \\ []) do
-    opts = Keyword.put_new(opts, :fmt_type_fun, &mock_fmt/1)
-    opts = Keyword.put_new(opts, :colors, false)
+    opts = Keyword.put_new(opts, :ex_fmt_type_fun, &mock_fmt/1)
+    opts = Keyword.put_new(opts, :ex_colors, use_colors: false)
 
     error
     |> ElixirFmt.format_error(opts)
@@ -281,8 +281,8 @@ defmodule Gradient.ElixirFmtTest do
   end
 
   defp type_format_error_to_binary(error, opts \\ []) do
-    opts = Keyword.put_new(opts, :fmt_expr_fun, &mock_fmt/1)
-    opts = Keyword.put_new(opts, :colors, false)
+    opts = Keyword.put_new(opts, :ex_fmt_expr_fun, &mock_fmt/1)
+    opts = Keyword.put_new(opts, :ex_colors, use_colors: false)
 
     error
     |> ElixirFmt.format_error(opts)

--- a/test/support/expr_data.ex
+++ b/test/support/expr_data.ex
@@ -20,7 +20,7 @@ defmodule Gradient.ExprData do
 
   def value_test_data() do
     [
-      {"geric atom", {:atom, 0, :fjdksaose}, ":fjdksaose"},
+      {"geric atom", {:atom, 0, :fjdksaose}, ~s(:"fjdksaose")},
       {"module atom", {:atom, 0, Gradient.ElixirExpr}, "Gradient.ElixirExpr"},
       {"nil atom", {:atom, 0, nil}, "nil"},
       {"true atom", {:atom, 0, true}, "true"},
@@ -42,7 +42,7 @@ defmodule Gradient.ExprData do
         {:cons, 0, {:integer, 0, 1}, {:cons, 0, {:integer, 0, 2}, {nil, 0}}}}, "[0, 1, 2]"},
       {"mixed list",
        {:cons, 0, {:integer, 0, 0},
-        {:cons, 0, {:atom, 0, :ok}, {:cons, 0, {:integer, 0, 2}, {nil, 0}}}}, "[0, :ok, 2]"},
+        {:cons, 0, {:atom, 0, :ok}, {:cons, 0, {:integer, 0, 2}, {nil, 0}}}}, ~s([0, :"ok", 2])},
       {"var in list", {:cons, 0, {:integer, 0, 0}, {:cons, 0, {:var, 0, :a}, {nil, 0}}},
        "[0, a]"},
       {"list tail pm", elixir_to_ast([a | t] = [12, 13, 14]), "[a | t] = [12, 13, 14]"},
@@ -71,7 +71,7 @@ defmodule Gradient.ExprData do
 
   def exception_test_data() do
     [
-      {"throw", elixir_to_ast(throw({:ok, 12})), "throw {:ok, 12}"},
+      {"throw", elixir_to_ast(throw({:ok, 12})), ~s(throw {:"ok", 12})},
       {"raise/1", elixir_to_ast(raise "test error"), ~s(raise "test error")},
       {"raise/1 without msg", elixir_to_ast(raise RuntimeError), "raise RuntimeError"},
       {"raise/2", elixir_to_ast(raise RuntimeError, "test error"), ~s(raise "test error")},
@@ -95,10 +95,10 @@ defmodule Gradient.ExprData do
   def map_test_data do
     [
       {"string map", elixir_to_ast(%{"a" => 12}), ~s(%{"a" => 12})},
-      {"map pm", elixir_to_ast(%{a: a} = %{a: 12}), "%{a: a} = %{a: 12}"},
-      {"update map", elixir_to_ast(%{%{} | a: 1}), "%{%{} | a: 1}"},
+      {"map pm", elixir_to_ast(%{a: a} = %{a: 12}), ~s(%{"a": a} = %{"a": 12})},
+      {"update map", elixir_to_ast(%{%{} | a: 1}), ~s(%{%{} | "a": 1})},
       {"struct expr", elixir_to_ast(%{__struct__: TestStruct, name: "John"}),
-       ~s(%TestStruct{name: "John"})}
+       ~s(%TestStruct{"name": "John"})}
     ]
   end
 
@@ -118,16 +118,16 @@ defmodule Gradient.ExprData do
        "\"String without escape codes \\x26 without \#{interpolation}\""},
       {"char lists", elixir_to_ast(~c(this is a char list containing 'single quotes')),
        "'this is a char list containing \\'single quotes\\''"},
-      {"word list", elixir_to_ast(~w(foo bar bat)), "[\"foo\", \"bar\", \"bat\"]"},
-      {"word list atom", elixir_to_ast(~w(foo bar bat)a), "[:foo, :bar, :bat]"},
+      {"word list", elixir_to_ast(~w(foo bar bat)), ~s(["foo", "bar", "bat"])},
+      {"word list atom", elixir_to_ast(~w(foo bar bat)a), ~s([:"foo", :"bar", :"bat"])},
       {"date", elixir_to_ast(~D[2019-10-31]),
-       "%Date{calendar: Calendar.ISO, year: 2019, month: 10, day: 31}"},
+       ~s(%Date{"calendar": Calendar.ISO, "year": 2019, "month": 10, "day": 31})},
       {"time", elixir_to_ast(~T[23:00:07.0]),
-       "%Time{calendar: Calendar.ISO, hour: 23, minute: 0, second: 7, microsecond: {0, 1}}"},
+       ~s(%Time{"calendar": Calendar.ISO, "hour": 23, "minute": 0, "second": 7, "microsecond": {0, 1}})},
       {"naive date time", elixir_to_ast(~N[2019-10-31 23:00:07]),
-       "%NaiveDateTime{calendar: Calendar.ISO, year: 2019, month: 10, day: 31, hour: 23, minute: 0, second: 7, microsecond: {0, 0}}"},
+       ~s(%NaiveDateTime{"calendar": Calendar.ISO, "year": 2019, "month": 10, "day": 31, "hour": 23, "minute": 0, "second": 7, "microsecond": {0, 0}})},
       {"date time", elixir_to_ast(~U[2019-10-31 19:59:03Z]),
-       "%DateTime{calendar: Calendar.ISO, year: 2019, month: 10, day: 31, hour: 19, minute: 59, second: 3, microsecond: {0, 0}, time_zone: \"Etc/UTC\", zone_abbr: \"UTC\", utc_offset: 0, std_offset: 0}"}
+       ~s(%DateTime{"calendar": Calendar.ISO, "year": 2019, "month": 10, "day": 31, "hour": 19, "minute": 59, "second": 3, "microsecond": {0, 0}, "time_zone": "Etc/UTC", "zone_abbr": "UTC", "utc_offset": 0, "std_offset": 0})}
     ]
   end
 
@@ -195,15 +195,16 @@ defmodule Gradient.ExprData do
   end
 
   defp regex_exp() do
-    <<37, 82, 101, 103, 101, 120, 123, 111, 112, 116, 115, 58, 32, 60, 60, 62, 62, 44, 32, 114,
-      101, 95, 112, 97, 116, 116, 101, 114, 110, 58, 32, 123, 58, 114, 101, 95, 112, 97, 116, 116,
-      101, 114, 110, 44, 32, 48, 44, 32, 48, 44, 32, 48, 44, 32, 34, 69, 82, 67, 80, 86, 0, 0, 0,
-      0, 0, 0, 0, 1, 0, 0, 0, 195, 191, 195, 191, 195, 191, 195, 191, 195, 191, 195, 191, 195,
-      191, 195, 191, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 194, 131, 0, 9, 29, 102, 29, 111, 29, 111, 119,
-      0, 9, 29, 98, 29, 97, 29, 114, 120, 0, 18, 0, 34, 125, 44, 32, 114, 101, 95, 118, 101, 114,
-      115, 105, 111, 110, 58, 32, 123, 34, 56, 46, 52, 52, 32, 50, 48, 50, 48, 45, 48, 50, 45, 49,
-      50, 34, 44, 32, 58, 108, 105, 116, 116, 108, 101, 125, 44, 32, 115, 111, 117, 114, 99, 101,
-      58, 32, 34, 102, 111, 111, 124, 98, 97, 114, 34, 125>>
+    <<37, 82, 101, 103, 101, 120, 123, 34, 111, 112, 116, 115, 34, 58, 32, 60, 60, 62, 62, 44, 32,
+      34, 114, 101, 95, 112, 97, 116, 116, 101, 114, 110, 34, 58, 32, 123, 58, 34, 114, 101, 95,
+      112, 97, 116, 116, 101, 114, 110, 34, 44, 32, 48, 44, 32, 48, 44, 32, 48, 44, 32, 34, 69,
+      82, 67, 80, 86, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 195, 191, 195, 191, 195, 191, 195, 191,
+      195, 191, 195, 191, 195, 191, 195, 191, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 194, 131, 0, 9, 29,
+      102, 29, 111, 29, 111, 119, 0, 9, 29, 98, 29, 97, 29, 114, 120, 0, 18, 0, 34, 125, 44, 32,
+      34, 114, 101, 95, 118, 101, 114, 115, 105, 111, 110, 34, 58, 32, 123, 34, 56, 46, 52, 52,
+      32, 50, 48, 50, 48, 45, 48, 50, 45, 49, 50, 34, 44, 32, 58, 34, 108, 105, 116, 116, 108,
+      101, 34, 125, 44, 32, 34, 115, 111, 117, 114, 99, 101, 34, 58, 32, 34, 102, 111, 111, 124,
+      98, 97, 114, 34, 125>>
   end
 end

--- a/test/support/type_data.ex
+++ b/test/support/type_data.ex
@@ -16,7 +16,7 @@ defmodule Gradient.TypeData do
   def value_test_data() do
     [
       {"integer value", {:integer, 0, 12}, "12"},
-      {"atom value", {:atom, 0, :ok}, ":ok"},
+      {"atom value", {:atom, 0, :ok}, ~s(:"ok")},
       {"boolean false", {:atom, 0, false}, "false"},
       {"boolean true", {:atom, 0, true}, "true"},
       {"nil", {:atom, 0, nil}, "nil"}
@@ -49,7 +49,7 @@ defmodule Gradient.TypeData do
     [
       {"any fun type", {:type, 0, :fun, []}, "fun()"},
       {"fun with any args returning a specific type",
-       {:type, 0, :fun, [{:type, 0, :any}, {:atom, 0, :ok}]}, "(... -> :ok)"},
+       {:type, 0, :fun, [{:type, 0, :any}, {:atom, 0, :ok}]}, ~s((... -> :"ok"\))},
       {"fun with specific arg types returning a specific type",
        {:type, 0, :fun, [{:type, 0, :product, [{:type, 0, :atom, []}]}, {:type, 0, :atom, []}]},
        "(atom() -> atom())"}
@@ -64,14 +64,14 @@ defmodule Gradient.TypeData do
         [
           {:type, 0, :map_field_assoc, [{:atom, 0, :value_a}, {:integer, 0, 5}]},
           {:type, 0, :map_field_exact, [{:atom, 0, :value_b}, {:atom, 0, :neo}]}
-        ]}, "%{optional(:value_a) => 5, required(:value_b) => :neo}"}
+        ]}, ~s(%{optional(:"value_a"\) => 5, required(:"value_b"\) => :"neo"})}
     ]
   end
 
   def tuple_types_test_data() do
     [
       {"any tuple type", {:type, 0, :tuple, :any}, "tuple()"},
-      {"tuple {:ok, 8}", {:type, 0, :tuple, [{:atom, 0, :ok}, {:integer, 0, 8}]}, "{:ok, 8}"}
+      {"tuple {:ok, 8}", {:type, 0, :tuple, [{:atom, 0, :ok}, {:integer, 0, 8}]}, ~s({:"ok", 8})}
     ]
   end
 


### PR DESCRIPTION
This PR addresses #25, #34, #30.

### Changes
- Each atom is printed in double-quoted form `: "dog"` and then Elixir formatter decides when to get rid of quotes.
- Pretty printed types or expressions are now formatted by Elixir formatter.
- Add the possibility to change the configuration of the colors by passing it as an option.
- Now errors formatted in Gradient and Gradualizer use the same ASCII colors configuration.