### PR TITLE
Get rid of leading slash in paths for load function

### DIFF
--- a/test/gradient/ast_specifier_test.exs
+++ b/test/gradient/ast_specifier_test.exs
@@ -19,7 +19,7 @@ defmodule Gradient.AstSpecifierTest do
     end
 
     test "integer" do
-      {tokens, ast} = load("/basic/Elixir.Basic.Int.beam", "/basic/int.ex")
+      {tokens, ast} = load("basic/Elixir.Basic.Int.beam", "basic/int.ex")
 
       [block, inline | _] = AstSpecifier.run_mappers(ast, tokens) |> Enum.reverse()
 
@@ -29,7 +29,7 @@ defmodule Gradient.AstSpecifierTest do
     end
 
     test "float" do
-      {tokens, ast} = load("/basic/Elixir.Basic.Float.beam", "/basic/float.ex")
+      {tokens, ast} = load("basic/Elixir.Basic.Float.beam", "basic/float.ex")
 
       [block, inline | _] = AstSpecifier.run_mappers(ast, tokens) |> Enum.reverse()
       assert {:function, 2, :float, 0, [{:clause, 2, [], [], [{:float, 2, 0.12}]}]} = inline
@@ -38,7 +38,7 @@ defmodule Gradient.AstSpecifierTest do
     end
 
     test "atom" do
-      {tokens, ast} = load("/basic/Elixir.Basic.Atom.beam", "/basic/atom.ex")
+      {tokens, ast} = load("basic/Elixir.Basic.Atom.beam", "basic/atom.ex")
 
       [block, inline | _] = AstSpecifier.run_mappers(ast, tokens) |> Enum.reverse()
 
@@ -48,7 +48,7 @@ defmodule Gradient.AstSpecifierTest do
     end
 
     test "char" do
-      {tokens, ast} = load("/basic/Elixir.Basic.Char.beam", "/basic/char.ex")
+      {tokens, ast} = load("basic/Elixir.Basic.Char.beam", "basic/char.ex")
 
       [block, inline | _] = AstSpecifier.run_mappers(ast, tokens) |> Enum.reverse()
 
@@ -58,7 +58,7 @@ defmodule Gradient.AstSpecifierTest do
     end
 
     test "charlist" do
-      {tokens, ast} = load("/basic/Elixir.Basic.Charlist.beam", "/basic/charlist.ex")
+      {tokens, ast} = load("basic/Elixir.Basic.Charlist.beam", "basic/charlist.ex")
 
       [block, inline | _] = AstSpecifier.run_mappers(ast, tokens) |> Enum.reverse()
 
@@ -83,7 +83,7 @@ defmodule Gradient.AstSpecifierTest do
     end
 
     test "string" do
-      {tokens, ast} = load("/basic/Elixir.Basic.String.beam", "/basic/string.ex")
+      {tokens, ast} = load("basic/Elixir.Basic.String.beam", "basic/string.ex")
 
       [block, inline | _] = AstSpecifier.run_mappers(ast, tokens) |> Enum.reverse()
 
@@ -101,7 +101,7 @@ defmodule Gradient.AstSpecifierTest do
     end
 
     test "tuple" do
-      {tokens, ast} = load("/Elixir.Tuple.beam", "/tuple.ex")
+      {tokens, ast} = load("Elixir.Tuple.beam", "tuple.ex")
 
       [tuple_in_str2, tuple_in_str, tuple_in_list, _list_in_tuple, tuple | _] =
         AstSpecifier.run_mappers(ast, tokens) |> Enum.reverse()
@@ -209,7 +209,7 @@ defmodule Gradient.AstSpecifierTest do
     end
 
     test "binary" do
-      {tokens, ast} = load("/basic/Elixir.Basic.Binary.beam", "/basic/binary.ex")
+      {tokens, ast} = load("basic/Elixir.Basic.Binary.beam", "basic/binary.ex")
 
       [complex2, complex, bin_block, bin | _] =
         AstSpecifier.run_mappers(ast, tokens)
@@ -279,7 +279,7 @@ defmodule Gradient.AstSpecifierTest do
     end
 
     test "case conditional" do
-      {tokens, ast} = load("/conditional/Elixir.Conditional.Case.beam", "/conditional/case.ex")
+      {tokens, ast} = load("conditional/Elixir.Conditional.Case.beam", "conditional/case.ex")
 
       [block, inline | _] = AstSpecifier.run_mappers(ast, tokens) |> Enum.reverse()
 
@@ -309,7 +309,7 @@ defmodule Gradient.AstSpecifierTest do
     end
 
     test "if conditional" do
-      {tokens, ast} = load("/conditional/Elixir.Conditional.If.beam", "/conditional/if.ex")
+      {tokens, ast} = load("conditional/Elixir.Conditional.If.beam", "conditional/if.ex")
 
       [block, inline, if_ | _] = AstSpecifier.run_mappers(ast, tokens) |> Enum.reverse()
 
@@ -360,8 +360,7 @@ defmodule Gradient.AstSpecifierTest do
     end
 
     test "unless conditional" do
-      {tokens, ast} =
-        load("/conditional/Elixir.Conditional.Unless.beam", "/conditional/unless.ex")
+      {tokens, ast} = load("conditional/Elixir.Conditional.Unless.beam", "conditional/unless.ex")
 
       [block | _] = AstSpecifier.run_mappers(ast, tokens) |> Enum.reverse()
 
@@ -386,7 +385,7 @@ defmodule Gradient.AstSpecifierTest do
     end
 
     test "cond conditional" do
-      {tokens, ast} = load("/conditional/Elixir.Conditional.Cond.beam", "/conditional/cond.ex")
+      {tokens, ast} = load("conditional/Elixir.Conditional.Cond.beam", "conditional/cond.ex")
 
       [block, inline | _] = AstSpecifier.run_mappers(ast, tokens) |> Enum.reverse()
 
@@ -457,7 +456,7 @@ defmodule Gradient.AstSpecifierTest do
     end
 
     test "with conditional" do
-      {tokens, ast} = load("/conditional/Elixir.Conditional.With.beam", "/conditional/with.ex")
+      {tokens, ast} = load("conditional/Elixir.Conditional.With.beam", "conditional/with.ex")
 
       [block | _] = AstSpecifier.run_mappers(ast, tokens) |> Enum.reverse()
 
@@ -489,8 +488,8 @@ defmodule Gradient.AstSpecifierTest do
 
     @tag :skip
     test "basic function return" do
-      ex_file = "/basic.ex"
-      beam_file = "/Elixir.Basic.beam"
+      ex_file = "basic.ex"
+      beam_file = "Elixir.Basic.beam"
       {tokens, ast} = load(beam_file, ex_file)
 
       specified_ast = AstSpecifier.run_mappers(ast, tokens)
@@ -535,7 +534,7 @@ defmodule Gradient.AstSpecifierTest do
   end
 
   test "function call" do
-    {tokens, ast} = load("/Elixir.Call.beam", "/call.ex")
+    {tokens, ast} = load("Elixir.Call.beam", "call.ex")
 
     [call, _ | _] = AstSpecifier.run_mappers(ast, tokens) |> Enum.reverse()
 
@@ -555,7 +554,7 @@ defmodule Gradient.AstSpecifierTest do
   end
 
   test "pipe" do
-    {tokens, ast} = load("/Elixir.Pipe.beam", "/pipe_op.ex")
+    {tokens, ast} = load("Elixir.Pipe.beam", "pipe_op.ex")
 
     [block | _] = AstSpecifier.run_mappers(ast, tokens) |> Enum.reverse()
 
@@ -587,7 +586,7 @@ defmodule Gradient.AstSpecifierTest do
   end
 
   test "guards" do
-    {tokens, ast} = load("/conditional/Elixir.Conditional.Guard.beam", "/conditional/guards.ex")
+    {tokens, ast} = load("conditional/Elixir.Conditional.Guard.beam", "conditional/guards.ex")
 
     [guarded_case, guarded_fun | _] = AstSpecifier.run_mappers(ast, tokens) |> Enum.reverse()
 
@@ -627,7 +626,7 @@ defmodule Gradient.AstSpecifierTest do
   end
 
   test "range" do
-    {tokens, ast} = load("/Elixir.RangeEx.beam", "/range.ex")
+    {tokens, ast} = load("Elixir.RangeEx.beam", "range.ex")
 
     [to_list, match_range, rev_range_step, range_step, range | _] =
       AstSpecifier.run_mappers(ast, tokens) |> Enum.reverse()
@@ -708,7 +707,7 @@ defmodule Gradient.AstSpecifierTest do
   end
 
   test "list comprehension" do
-    {tokens, ast} = load("/Elixir.ListComprehension.beam", "/list_comprehension.ex")
+    {tokens, ast} = load("Elixir.ListComprehension.beam", "list_comprehension.ex")
 
     [block | _] = AstSpecifier.run_mappers(ast, tokens) |> Enum.reverse()
 
@@ -758,7 +757,7 @@ defmodule Gradient.AstSpecifierTest do
   end
 
   test "list" do
-    {tokens, ast} = load("/Elixir.ListEx.beam", "/list.ex")
+    {tokens, ast} = load("Elixir.ListEx.beam", "list.ex")
 
     [ht2, ht, list, _wrap | _] = AstSpecifier.run_mappers(ast, tokens) |> Enum.reverse()
 
@@ -798,7 +797,7 @@ defmodule Gradient.AstSpecifierTest do
   end
 
   test "try" do
-    {tokens, ast} = load("/Elixir.Try.beam", "/try.ex")
+    {tokens, ast} = load("Elixir.Try.beam", "try.ex")
 
     [body_after, try_after, try_else, try_rescue | _] =
       AstSpecifier.run_mappers(ast, tokens) |> Enum.reverse()
@@ -981,7 +980,7 @@ defmodule Gradient.AstSpecifierTest do
   end
 
   test "map" do
-    {tokens, ast} = load("/Elixir.MapEx.beam", "/map.ex")
+    {tokens, ast} = load("Elixir.MapEx.beam", "map.ex")
 
     [pattern_matching_str, pattern_matching, test_map_str, test_map, empty_map | _] =
       AstSpecifier.run_mappers(ast, tokens) |> Enum.reverse()
@@ -1045,7 +1044,7 @@ defmodule Gradient.AstSpecifierTest do
   end
 
   test "struct" do
-    {tokens, ast} = load("/struct/Elixir.StructEx.beam", "/struct/struct.ex")
+    {tokens, ast} = load("struct/Elixir.StructEx.beam", "struct/struct.ex")
 
     [get2, get, update, empty, struct | _] =
       AstSpecifier.run_mappers(ast, tokens) |> Enum.reverse()
@@ -1162,7 +1161,7 @@ defmodule Gradient.AstSpecifierTest do
   end
 
   test "record" do
-    {tokens, ast} = load("/record/Elixir.RecordEx.beam", "/record/record.ex")
+    {tokens, ast} = load("record/Elixir.RecordEx.beam", "record/record.ex")
 
     [update, init, empty, macro3, macro2, macro1 | _] =
       AstSpecifier.run_mappers(ast, tokens) |> Enum.reverse()
@@ -1245,7 +1244,7 @@ defmodule Gradient.AstSpecifierTest do
   end
 
   test "receive" do
-    {tokens, ast} = load("/Elixir.Receive.beam", "/receive.ex")
+    {tokens, ast} = load("Elixir.Receive.beam", "receive.ex")
 
     [recv, recv2 | _] = AstSpecifier.run_mappers(ast, tokens) |> Enum.reverse()
 
@@ -1295,7 +1294,7 @@ defmodule Gradient.AstSpecifierTest do
   end
 
   test "typespec" do
-    {tokens, ast} = load("/Elixir.Typespec.beam", "/typespec.ex")
+    {tokens, ast} = load("Elixir.Typespec.beam", "typespec.ex")
 
     [atoms_type2, atoms_type, named_type, missing_type_arg, missing_type | _] =
       AstSpecifier.run_mappers(ast, tokens)

--- a/test/gradient/elixir_fmt_test.exs
+++ b/test/gradient/elixir_fmt_test.exs
@@ -294,7 +294,7 @@ defmodule Gradient.ElixirFmtTest do
 
   @spec load_record_type_example(map()) :: map()
   defp load_record_type_example(config) do
-    {_tokens, ast} = load("/type/Elixir.RecordEx.beam", "/type/record.ex")
+    {_tokens, ast} = load("type/Elixir.RecordEx.beam", "type/record.ex")
 
     {errors, forms} = type_check_file(ast, [])
 
@@ -311,7 +311,7 @@ defmodule Gradient.ElixirFmtTest do
 
   @spec load_wrong_ret_error_examples(map()) :: map()
   defp load_wrong_ret_error_examples(config) do
-    {_tokens, ast} = load("/type/Elixir.WrongRet.beam", "/type/wrong_ret.ex")
+    {_tokens, ast} = load("type/Elixir.WrongRet.beam", "type/wrong_ret.ex")
 
     {errors, forms} = type_check_file(ast, [])
     names = get_function_names_from_ast(forms)

--- a/test/gradient/tokens_test.exs
+++ b/test/gradient/tokens_test.exs
@@ -47,7 +47,7 @@ defmodule Gradient.TokensTest do
 
   describe "get_conditional/1" do
     test "case" do
-      {tokens, _ast} = load("/conditional/Elixir.Conditional.Case.beam", "/conditional/case.ex")
+      {tokens, _ast} = load("conditional/Elixir.Conditional.Case.beam", "conditional/case.ex")
       tokens = Tokens.drop_tokens_to_line(tokens, 2)
       opts = [end_line: -1]
       assert {:case, _} = Tokens.get_conditional(tokens, 4, opts)
@@ -57,7 +57,7 @@ defmodule Gradient.TokensTest do
     end
 
     test "if" do
-      {tokens, _ast} = load("/conditional/Elixir.Conditional.If.beam", "/conditional/if.ex")
+      {tokens, _ast} = load("conditional/Elixir.Conditional.If.beam", "conditional/if.ex")
       tokens = Tokens.drop_tokens_to_line(tokens, 2)
       opts = [end_line: -1]
       assert {:if, _} = Tokens.get_conditional(tokens, 4, opts)
@@ -68,7 +68,7 @@ defmodule Gradient.TokensTest do
 
     test "unless" do
       {tokens, _ast} =
-        load("/conditional/Elixir.Conditional.Unless.beam", "/conditional/unless.ex")
+        load("conditional/Elixir.Conditional.Unless.beam", "conditional/unless.ex")
 
       tokens = Tokens.drop_tokens_to_line(tokens, 2)
       opts = [end_line: -1]
@@ -76,7 +76,7 @@ defmodule Gradient.TokensTest do
     end
 
     test "cond" do
-      {tokens, _ast} = load("/conditional/Elixir.Conditional.Cond.beam", "/conditional/cond.ex")
+      {tokens, _ast} = load("conditional/Elixir.Conditional.Cond.beam", "conditional/cond.ex")
 
       tokens = Tokens.drop_tokens_to_line(tokens, 2)
       opts = [end_line: -1]
@@ -87,7 +87,7 @@ defmodule Gradient.TokensTest do
     end
 
     test "with" do
-      {tokens, _ast} = load("/conditional/Elixir.Conditional.With.beam", "/conditional/with.ex")
+      {tokens, _ast} = load("conditional/Elixir.Conditional.With.beam", "conditional/with.ex")
 
       tokens = Tokens.drop_tokens_to_line(tokens, 6)
       opts = [end_line: -1]

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -1,7 +1,7 @@
 defmodule Gradient.TestHelpers do
   alias Gradient.Types, as: T
 
-  @examples_path "test/examples"
+  @examples_path "test/examples/"
 
   @spec load(String.t(), String.t()) :: {T.tokens(), T.forms()}
   def load(beam_file, ex_file) do
@@ -25,8 +25,8 @@ defmodule Gradient.TestHelpers do
 
   @spec example_data() :: {T.tokens(), T.forms()}
   def example_data() do
-    beam_path = (@examples_path <> "/Elixir.SimpleApp.beam") |> String.to_charlist()
-    file_path = @examples_path <> "/simple_app.ex"
+    beam_path = (@examples_path <> "Elixir.SimpleApp.beam") |> String.to_charlist()
+    file_path = @examples_path <> "simple_app.ex"
 
     code =
       File.read!(file_path)
@@ -45,7 +45,7 @@ defmodule Gradient.TestHelpers do
 
   @spec example_tokens() :: T.tokens()
   def example_tokens() do
-    file_path = @examples_path <> "/conditional/cond.ex"
+    file_path = @examples_path <> "conditional/cond.ex"
 
     code =
       File.read!(file_path)
@@ -60,7 +60,7 @@ defmodule Gradient.TestHelpers do
 
   @spec example_string_tokens() :: T.tokens()
   def example_string_tokens() do
-    file_path = @examples_path <> "/string_example.ex"
+    file_path = @examples_path <> "string_example.ex"
 
     code =
       File.read!(file_path)


### PR DESCRIPTION
This PR addresses problem pointed out in this comment [https://github.com/esl/gradient/pull/27#discussion_r809916233](https://github.com/esl/gradient/pull/27#discussion_r809916233).

