### PR TITLE
Update TypedServer demo

### DIFF
--- a/examples/typed_gen_server/lib/typed_gen_server/stage1.ex
+++ b/examples/typed_gen_server/lib/typed_gen_server/stage1.ex
@@ -23,7 +23,6 @@ defmodule TypedGenServer.Stage1.Server do
   end
 
   @spec echo(pid(), String.t()) :: String.t()
-  # @spec echo(pid(), String.t()) :: {:echo_req, String.t()}
   def echo(pid, message) do
     case annotate_type(GenServer.call(pid, {:echo_req, message}), Contract.Echo.res()) do
       # case call_echo(pid, message) do

--- a/examples/typed_gen_server/lib/typed_gen_server/stage1.ex
+++ b/examples/typed_gen_server/lib/typed_gen_server/stage1.ex
@@ -1,12 +1,12 @@
 defmodule TypedGenServer.Stage1.Server do
   use GenServer
-  use GradualizerEx.TypeAnnotation
+  use Gradient.TypeAnnotation
 
   ## Start IEx with:
   ##   iex -S mix run --no-start
   ##
   ## Then use the following to recheck the file on any change:
-  ##   recompile(); GradualizerEx.type_check_file(:code.which( TypedGenServer.Stage1.Server ), [:infer])
+  ##   recompile(); Gradient.type_check_file(:code.which( TypedGenServer.Stage1.Server ), [:infer])
 
   ## Try switching between the definitions and see what happens
   @type message :: Contract.Echo.req() | Contract.Hello.req()

--- a/examples/typed_gen_server/lib/typed_gen_server/stage1.ex
+++ b/examples/typed_gen_server/lib/typed_gen_server/stage1.ex
@@ -10,8 +10,8 @@ defmodule TypedGenServer.Stage1.Server do
 
   ## Try switching between the definitions and see what happens
   @type message :: Contract.Echo.req() | Contract.Hello.req()
-  #@type message :: Contract.Echo.req()
-  #@type message :: {:echo_req, String.t()} | {:hello, String.t()}
+  # @type message :: Contract.Echo.req()
+  # @type message :: {:echo_req, String.t()} | {:hello, String.t()}
 
   @type state :: map()
 
@@ -22,17 +22,17 @@ defmodule TypedGenServer.Stage1.Server do
   @spec echo(pid(), String.t()) :: String.t()
   # @spec echo(pid(), String.t()) :: {:echo_req, String.t()}
   def echo(pid, message) do
-    case annotate_type( GenServer.call(pid, {:echo_req, message}), Contract.Echo.res() ) do
-    #case call_echo(pid, message) do
+    case annotate_type(GenServer.call(pid, {:echo_req, message}), Contract.Echo.res()) do
+      # case call_echo(pid, message) do
       ## Try changing the pattern or the returned response
       {:echo_res, response} -> response
     end
   end
 
-  #@spec call_echo(pid(), String.t()) :: Contract.Echo.res()
-  #defp call_echo(pid, message) do
+  # @spec call_echo(pid(), String.t()) :: Contract.Echo.res()
+  # defp call_echo(pid, message) do
   #  GenServer.call(pid, {:echo_req, message})
-  #end
+  # end
 
   @spec hello(pid(), String.t()) :: :ok
   def hello(pid, name) do

--- a/examples/typed_gen_server/lib/typed_gen_server/stage1.ex
+++ b/examples/typed_gen_server/lib/typed_gen_server/stage1.ex
@@ -49,22 +49,20 @@ defmodule TypedGenServer.Stage1.Server do
     {:ok, state}
   end
 
-  # @impl true
-  def handle_call(m, from, state) do
-    {:noreply, handle(m, from, state)}
-  end
+  @type called(a) :: {:noreply, state()}
+                   | {:reply, a, state()}
 
-  @spec handle(message(), any, any) :: state()
+  # @impl true
+  @spec handle_call(message(), GenServer.from(), state())
+          :: called(Contract.Echo.res() | Contract.Hello.res())
   ## Try breaking the pattern match, e.g. by changing 'echo_req'
-  def handle({:echo_req, payload}, from, state) do
-    GenServer.reply(from, {:echo_res, payload})
-    state
+  def handle_call({:echo_req, payload}, _from, state) do
+    {:reply, {:echo_res, payload}, state}
   end
 
   ## Try commenting out the following clause
-  def handle({:hello, name}, from, state) do
+  def handle_call({:hello, name}, _from, state) do
     IO.puts("Hello, #{name}!")
-    GenServer.reply(from, :ok)
-    state
+    {:reply, :ok, state}
   end
 end

--- a/examples/typed_gen_server/lib/typed_gen_server/stage1.ex
+++ b/examples/typed_gen_server/lib/typed_gen_server/stage1.ex
@@ -5,6 +5,9 @@ defmodule TypedGenServer.Stage1.Server do
   ## Start IEx with:
   ##   iex -S mix run --no-start
   ##
+  ## Start Gradient:
+  ##   Application.ensure_all_started(:gradient)
+  ##
   ## Then use the following to recheck the file on any change:
   ##   recompile(); Gradient.type_check_file(:code.which( TypedGenServer.Stage1.Server ), [:infer])
 

--- a/examples/typed_gen_server/lib/typed_gen_server/stage1.ex
+++ b/examples/typed_gen_server/lib/typed_gen_server/stage1.ex
@@ -1,5 +1,5 @@
 defmodule TypedGenServer.Stage1.Server do
-  use GenServer
+  # use GenServer
   use Gradient.TypeAnnotation
 
   ## Start IEx with:
@@ -41,12 +41,12 @@ defmodule TypedGenServer.Stage1.Server do
     end
   end
 
-  @impl true
+  # @impl true
   def init(state) do
     {:ok, state}
   end
 
-  @impl true
+  # @impl true
   def handle_call(m, from, state) do
     {:noreply, handle(m, from, state)}
   end

--- a/examples/typed_gen_server/lib/typed_gen_server/stage2.ex
+++ b/examples/typed_gen_server/lib/typed_gen_server/stage2.ex
@@ -13,8 +13,8 @@ defmodule TypedGenServer.Stage2.Server do
 
   ## Try switching between the definitions and see what happens
   @type message :: Contract.Echo.req() | Contract.Hello.req()
-  #@type message :: Contract.Echo.req()
-  #@type message :: {:echo_req, String.t()} | {:hello, String.t()}
+  # @type message :: Contract.Echo.req()
+  # @type message :: {:echo_req, String.t()} | {:hello, String.t()}
 
   @type state :: map()
 
@@ -26,8 +26,8 @@ defmodule TypedGenServer.Stage2.Server do
   @spec echo(t(), String.t()) :: String.t()
   # @spec echo(t(), String.t()) :: {:echo_req, String.t()}
   def echo(pid, message) do
-    case annotate_type( GenServer.call(pid, {:echo_req, message}), Contract.Echo.res() ) do
-    #case call_echo(pid, message) do
+    case annotate_type(GenServer.call(pid, {:echo_req, message}), Contract.Echo.res()) do
+      # case call_echo(pid, message) do
       ## Try changing the pattern or the returned response
       {:echo_res, response} -> response
     end
@@ -62,8 +62,8 @@ defmodule TypedGenServer.Stage2.Server do
     ## This could register {:echo_req, payload} <-> {:echo_res, payload} mapping
     ## and response type at compile time to generate call_echo() automatically.
     ## Thanks Robert!
-    #TypedServer.reply( from, {:echo_res, payload}, Contract.Echo.res() )
-    GenServer.reply( from, {:echo_res, payload} )
+    # TypedServer.reply( from, {:echo_res, payload}, Contract.Echo.res() )
+    GenServer.reply(from, {:echo_res, payload})
     state
   end
 
@@ -87,6 +87,6 @@ defmodule Test.TypedGenServer.Stage2.Server do
     pid = self()
     "payload" = Server.echo(srv, "payload")
     ## This won't typecheck, since Server.echo only accepts Server.t(), that is our Server pids
-    #"payload" = Server.echo(pid, "payload")
+    # "payload" = Server.echo(pid, "payload")
   end
 end

--- a/examples/typed_gen_server/lib/typed_gen_server/stage2.ex
+++ b/examples/typed_gen_server/lib/typed_gen_server/stage2.ex
@@ -27,7 +27,6 @@ defmodule TypedGenServer.Stage2.Server do
   end
 
   @spec echo(t(), String.t()) :: String.t()
-  # @spec echo(t(), String.t()) :: {:echo_req, String.t()}
   def echo(pid, message) do
     case annotate_type(GenServer.call(pid, {:echo_req, message}), Contract.Echo.res()) do
       # case call_echo(pid, message) do
@@ -81,6 +80,9 @@ end
 defmodule Test.TypedGenServer.Stage2.Server do
   alias TypedGenServer.Stage2.Server
 
+  ## Run with:
+  ##   recompile(); Test.TypedGenServer.Stage2.Server.test()
+  ##
   ## Typecheck with:
   ##   recompile(); Gradient.type_check_file(:code.which( Test.TypedGenServer.Stage2.Server ), [:infer])
   ##   recompile(); Gradient.type_check_file(:code.which( Test.TypedGenServer.Stage2.Server ), [:infer, ex_check: false])

--- a/examples/typed_gen_server/lib/typed_gen_server/stage2.ex
+++ b/examples/typed_gen_server/lib/typed_gen_server/stage2.ex
@@ -1,13 +1,13 @@
 defmodule TypedGenServer.Stage2.Server do
   use GenServer
-  use GradualizerEx.TypeAnnotation
+  use Gradient.TypeAnnotation
   alias Stage2.TypedServer
 
   ## Start IEx with:
   ##   iex -S mix run --no-start
   ##
   ## Then use the following to recheck the file on any change:
-  ##   recompile(); GradualizerEx.type_check_file(:code.which( TypedGenServer.Stage2.Server ), [:infer])
+  ##   recompile(); Gradient.type_check_file(:code.which( TypedGenServer.Stage2.Server ), [:infer])
 
   @opaque t :: pid()
 
@@ -79,7 +79,7 @@ defmodule Test.TypedGenServer.Stage2.Server do
   alias TypedGenServer.Stage2.Server
 
   ## Typecheck with:
-  ##   recompile(); GradualizerEx.type_check_file(:code.which( Test.TypedGenServer.Stage2.Server ), [:infer])
+  ##   recompile(); Gradient.type_check_file(:code.which( Test.TypedGenServer.Stage2.Server ), [:infer])
 
   @spec test :: any()
   def test do

--- a/examples/typed_gen_server/lib/typed_gen_server/stage2.ex
+++ b/examples/typed_gen_server/lib/typed_gen_server/stage2.ex
@@ -80,6 +80,7 @@ defmodule Test.TypedGenServer.Stage2.Server do
 
   ## Typecheck with:
   ##   recompile(); Gradient.type_check_file(:code.which( Test.TypedGenServer.Stage2.Server ), [:infer])
+  ##   recompile(); Gradient.type_check_file(:code.which( Test.TypedGenServer.Stage2.Server ), [:infer, ex_check: false])
 
   @spec test :: any()
   def test do

--- a/examples/typed_gen_server/lib/typed_gen_server/stage2.ex
+++ b/examples/typed_gen_server/lib/typed_gen_server/stage2.ex
@@ -6,6 +6,9 @@ defmodule TypedGenServer.Stage2.Server do
   ## Start IEx with:
   ##   iex -S mix run --no-start
   ##
+  ## Start Gradient:
+  ##   Application.ensure_all_started(:gradient)
+  ##
   ## Then use the following to recheck the file on any change:
   ##   recompile(); Gradient.type_check_file(:code.which( TypedGenServer.Stage2.Server ), [:infer])
 

--- a/examples/typed_gen_server/lib/typed_gen_server/stage2.ex
+++ b/examples/typed_gen_server/lib/typed_gen_server/stage2.ex
@@ -84,7 +84,14 @@ defmodule Test.TypedGenServer.Stage2.Server do
   @spec test :: any()
   def test do
     {:ok, srv} = Server.start_link()
-    pid = self()
+
+    pid =
+      spawn(fn ->
+        receive do
+          :unlikely -> :ok
+        end
+      end)
+
     "payload" = Server.echo(srv, "payload")
     ## This won't typecheck, since Server.echo only accepts Server.t(), that is our Server pids
     # "payload" = Server.echo(pid, "payload")

--- a/examples/typed_gen_server/lib/typed_gen_server/stage2.ex
+++ b/examples/typed_gen_server/lib/typed_gen_server/stage2.ex
@@ -1,5 +1,5 @@
 defmodule TypedGenServer.Stage2.Server do
-  use GenServer
+  # use GenServer
   use Gradient.TypeAnnotation
   alias Stage2.TypedServer
 
@@ -46,12 +46,12 @@ defmodule TypedGenServer.Stage2.Server do
     end
   end
 
-  @impl true
+  # @impl true
   def init(state) do
     {:ok, state}
   end
 
-  @impl true
+  # @impl true
   def handle_call(m, from, state) do
     {:noreply, handle(m, from, state)}
   end

--- a/examples/typed_gen_server/lib/typed_gen_server/stage3.ex
+++ b/examples/typed_gen_server/lib/typed_gen_server/stage3.ex
@@ -18,14 +18,14 @@ end
 
 defmodule TypedGenServer.Stage3.Server do
   use GenServer
-  use GradualizerEx.TypeAnnotation
+  use Gradient.TypeAnnotation
   alias Stage3.TypedServer
 
   ## Start IEx with:
   ##   iex -S mix run --no-start
   ##
   ## Then use the following to recheck the file on any change:
-  ##   recompile(); GradualizerEx.type_check_file(:code.which( TypedGenServer.Stage3.Server ), [:infer])
+  ##   recompile(); Gradient.type_check_file(:code.which( TypedGenServer.Stage3.Server ), [:infer])
 
   @opaque t :: {__MODULE__, pid()}
 
@@ -92,7 +92,7 @@ defmodule Test.TypedGenServer.Stage3.Server do
   alias TypedGenServer.Stage3.Server
 
   ## Typecheck with:
-  ##   recompile(); GradualizerEx.type_check_file(:code.which( Test.TypedGenServer.Stage3.Server ), [:infer])
+  ##   recompile(); Gradient.type_check_file(:code.which( Test.TypedGenServer.Stage3.Server ), [:infer])
 
   @spec test :: any()
   def test do

--- a/examples/typed_gen_server/lib/typed_gen_server/stage3.ex
+++ b/examples/typed_gen_server/lib/typed_gen_server/stage3.ex
@@ -1,5 +1,4 @@
 defmodule Stage3.TypedServer do
-
   ## This doesn't play well with:
   ##   {:ok, srv} = MultiServer.start_link()
   ## Due to:
@@ -31,8 +30,8 @@ defmodule TypedGenServer.Stage3.Server do
 
   ## Try switching between the definitions and see what happens
   @type message :: Contract.Echo.req() | Contract.Hello.req()
-  #@type message :: Contract.Echo.req()
-  #@type message :: {:echo_req, String.t()} | {:hello, String.t()}
+  # @type message :: Contract.Echo.req()
+  # @type message :: {:echo_req, String.t()} | {:hello, String.t()}
 
   @type state :: map()
 
@@ -44,17 +43,17 @@ defmodule TypedGenServer.Stage3.Server do
   @spec echo(t(), String.t()) :: String.t()
   # @spec echo(t(), String.t()) :: {:echo_req, String.t()}
   def echo(_server = {__MODULE__, _pid}, message) do
-    case annotate_type( GenServer.call(_pid, {:echo_req, message}), Contract.Echo.res() ) do
-    #case call_echo(_server, message) do
+    case annotate_type(GenServer.call(_pid, {:echo_req, message}), Contract.Echo.res()) do
+      # case call_echo(_server, message) do
       ## Try changing the pattern or the returned response
       {:echo_res, response} -> response
     end
   end
 
-  #@spec call_echo(t(), String.t()) :: Contract.Echo.res()
-  #defp call_echo({__MODULE__, pid}, message) do
+  # @spec call_echo(t(), String.t()) :: Contract.Echo.res()
+  # defp call_echo({__MODULE__, pid}, message) do
   #  GenServer.call(pid, {:echo_req, message})
-  #end
+  # end
 
   @spec hello(t(), String.t()) :: :ok
   def hello({__MODULE__, pid}, name) do
@@ -100,6 +99,6 @@ defmodule Test.TypedGenServer.Stage3.Server do
     pid = self()
     "payload" = Server.echo(srv, "payload")
     ## This won't typecheck, since Server.echo only accepts Server.t(), that is Server pids
-    #"payload" = Server.echo(pid, "payload")
+    # "payload" = Server.echo(pid, "payload")
   end
 end

--- a/examples/typed_gen_server/lib/typed_gen_server/stage4.ex
+++ b/examples/typed_gen_server/lib/typed_gen_server/stage4.ex
@@ -27,7 +27,7 @@ defmodule TypedGenServer.Stage4.Server do
   @spec echo(t(), String.t()) :: String.t()
   # @spec echo(t(), String.t()) :: {:echo_req, String.t()}
   def echo(pid, message) do
-    #case annotate_type(GenServer.call(pid, {:echo_req, message}), Contract.Echo.res()) do
+    # case annotate_type(GenServer.call(pid, {:echo_req, message}), Contract.Echo.res()) do
     case call_echo_req(pid, message) do
       ## Try changing the pattern or the returned response
       {:echo_res, response} -> response
@@ -38,10 +38,10 @@ defmodule TypedGenServer.Stage4.Server do
   ## thanks to using TypedServer.reply/3 instead of GenServer.reply/2.
   ## We don't have to define it!
   ## TODO: use the correct type instead of any as the second param!
-  #@spec call_echo_req(t(), any) :: Contract.Echo.res()
-  #defp call_echo_req(pid, message) do
+  # @spec call_echo_req(t(), any) :: Contract.Echo.res()
+  # defp call_echo_req(pid, message) do
   #  GenServer.call(pid, {:echo_req, message})
-  #end
+  # end
 
   @spec hello(t(), String.t()) :: :ok
   def hello(pid, name) do
@@ -64,11 +64,11 @@ defmodule TypedGenServer.Stage4.Server do
     ## TypedServer.reply/3 registers a {:echo_req, payload} <-> Contract.Echo.res() mapping
     ## and generates call_echo_req() at compile time.
     ## Thanks for the idea, @rvirding!
-    TypedServer.reply( from, {:echo_res, payload}, Contract.Echo.res() )
+    TypedServer.reply(from, {:echo_res, payload}, Contract.Echo.res())
     ## This will not typecheck - awesome!
-    #TypedServer.reply( from, {:invalid_tag, payload}, Contract.Echo.res() )
+    # TypedServer.reply( from, {:invalid_tag, payload}, Contract.Echo.res() )
     ## And this is the well known untyped equivalent.
-    #GenServer.reply(from, {:echo_res, payload})
+    # GenServer.reply(from, {:echo_res, payload})
     state
   end
 
@@ -92,6 +92,6 @@ defmodule Test.TypedGenServer.Stage4.Server do
     pid = self()
     "payload" = Server.echo(srv, "payload")
     ## This won't typecheck, since Server.echo only accepts Server.t(), that is our Server pids
-    #"payload" = Server.echo(pid, "payload")
+    # "payload" = Server.echo(pid, "payload")
   end
 end

--- a/examples/typed_gen_server/lib/typed_gen_server/stage4.ex
+++ b/examples/typed_gen_server/lib/typed_gen_server/stage4.ex
@@ -89,7 +89,14 @@ defmodule Test.TypedGenServer.Stage4.Server do
   @spec test :: any()
   def test do
     {:ok, srv} = Server.start_link()
-    pid = self()
+
+    pid =
+      spawn(fn ->
+        receive do
+          :unlikely -> :ok
+        end
+      end)
+
     "payload" = Server.echo(srv, "payload")
     ## This won't typecheck, since Server.echo only accepts Server.t(), that is our Server pids
     # "payload" = Server.echo(pid, "payload")

--- a/examples/typed_gen_server/lib/typed_gen_server/stage4.ex
+++ b/examples/typed_gen_server/lib/typed_gen_server/stage4.ex
@@ -7,6 +7,9 @@ defmodule TypedGenServer.Stage4.Server do
   ## Start IEx with:
   ##   iex -S mix run --no-start
   ##
+  ## Start Gradient:
+  ##   Application.ensure_all_started(:gradient)
+  ##
   ## Then use the following to recheck the file on any change:
   ##   recompile(); Gradient.type_check_file(:code.which( TypedGenServer.Stage4.Server ), [:infer])
 

--- a/examples/typed_gen_server/lib/typed_gen_server/stage4.ex
+++ b/examples/typed_gen_server/lib/typed_gen_server/stage4.ex
@@ -85,6 +85,7 @@ defmodule Test.TypedGenServer.Stage4.Server do
 
   ## Typecheck with:
   ##   recompile(); Gradient.type_check_file(:code.which( Test.TypedGenServer.Stage4.Server ), [:infer])
+  ##   recompile(); Gradient.type_check_file(:code.which( Test.TypedGenServer.Stage4.Server ), [:infer, ex_check: false])
 
   @spec test :: any()
   def test do

--- a/examples/typed_gen_server/lib/typed_gen_server/stage4.ex
+++ b/examples/typed_gen_server/lib/typed_gen_server/stage4.ex
@@ -12,6 +12,7 @@ defmodule TypedGenServer.Stage4.Server do
   ##
   ## Then use the following to recheck the file on any change:
   ##   recompile(); Gradient.type_check_file(:code.which( TypedGenServer.Stage4.Server ), [:infer])
+  ##   recompile(); Gradient.type_check_file(:code.which( TypedGenServer.Stage4.Server ), [:infer, ex_check: false])
 
   @opaque t :: pid()
 

--- a/examples/typed_gen_server/lib/typed_gen_server/stage4.ex
+++ b/examples/typed_gen_server/lib/typed_gen_server/stage4.ex
@@ -1,5 +1,5 @@
 defmodule TypedGenServer.Stage4.Server do
-  use GenServer
+  # use GenServer
   use Gradient.TypeAnnotation
   use Gradient.TypedServer
   alias Gradient.TypedServer
@@ -48,12 +48,12 @@ defmodule TypedGenServer.Stage4.Server do
     GenServer.call(pid, {:hello, name})
   end
 
-  @impl true
+  # @impl true
   def init(state) do
     {:ok, state}
   end
 
-  @impl true
+  # @impl true
   def handle_call(m, from, state) do
     {:noreply, handle(m, from, state)}
   end

--- a/examples/typed_gen_server/mix.exs
+++ b/examples/typed_gen_server/mix.exs
@@ -26,8 +26,7 @@ defmodule TypedGenServer.MixProject do
       {:gradient, path: "../../"},
       {:dialyxir, "~> 1.1", only: [:dev, :test], runtime: false},
       {:gradualizer,
-       github: "erszcz/Gradualizer", ref: "typed-gen-server", manager: :rebar3, override: true},
-      {:gradualizer_ex, github: "erszcz/gradualizer-ex", branch: "rs/wip"}
+       github: "erszcz/Gradualizer", ref: "typed-gen-server", manager: :rebar3, override: true}
     ]
   end
 

--- a/examples/typed_gen_server/mix.exs
+++ b/examples/typed_gen_server/mix.exs
@@ -24,7 +24,9 @@ defmodule TypedGenServer.MixProject do
   defp deps do
     [
       {:gradient, path: "../../"},
-      {:dialyxir, "~> 1.1", only: [:dev, :test], runtime: false}
+      {:dialyxir, "~> 1.1", only: [:dev, :test], runtime: false},
+      {:gradualizer,
+       github: "erszcz/Gradualizer", ref: "typed-gen-server", manager: :rebar3, override: true}
     ]
   end
 

--- a/examples/typed_gen_server/mix.exs
+++ b/examples/typed_gen_server/mix.exs
@@ -24,9 +24,7 @@ defmodule TypedGenServer.MixProject do
   defp deps do
     [
       {:gradient, path: "../../"},
-      {:dialyxir, "~> 1.1", only: [:dev, :test], runtime: false},
-      {:gradualizer,
-       github: "erszcz/Gradualizer", ref: "typed-gen-server", manager: :rebar3, override: true}
+      {:dialyxir, "~> 1.1", only: [:dev, :test], runtime: false}
     ]
   end
 

--- a/examples/typed_gen_server/mix.exs
+++ b/examples/typed_gen_server/mix.exs
@@ -31,7 +31,7 @@ defmodule TypedGenServer.MixProject do
   defp dialyzer do
     [
       plt_add_deps: :app_tree,
-      #ignore_warnings: "dialyzer.ignore-warnings",
+      # ignore_warnings: "dialyzer.ignore-warnings",
       flags: ~w(
         error_handling
         race_conditions
@@ -40,5 +40,4 @@ defmodule TypedGenServer.MixProject do
       )a
     ]
   end
-
 end

--- a/examples/typed_gen_server/mix.lock
+++ b/examples/typed_gen_server/mix.lock
@@ -1,5 +1,5 @@
 %{
   "dialyxir": {:hex, :dialyxir, "1.1.0", "c5aab0d6e71e5522e77beff7ba9e08f8e02bad90dfbeffae60eaf0cb47e29488", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "07ea8e49c45f15264ebe6d5b93799d4dd56a44036cf42d0ad9c960bc266c0b9a"},
   "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
-  "gradualizer": {:git, "https://github.com/josefs/Gradualizer.git", "6e89b4e1cd489637a848cc5ca55058c8a241bf7d", [ref: "6e89b4e"]},
+  "gradualizer": {:git, "https://github.com/erszcz/Gradualizer.git", "764ddc6b4cc007008ea68eb9ec7a3f3adc2f1951", [ref: "typed-gen-server"]},
 }

--- a/examples/typed_gen_server/mix.lock
+++ b/examples/typed_gen_server/mix.lock
@@ -1,5 +1,5 @@
 %{
   "dialyxir": {:hex, :dialyxir, "1.1.0", "c5aab0d6e71e5522e77beff7ba9e08f8e02bad90dfbeffae60eaf0cb47e29488", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "07ea8e49c45f15264ebe6d5b93799d4dd56a44036cf42d0ad9c960bc266c0b9a"},
   "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
-  "gradualizer": {:git, "https://github.com/erszcz/Gradualizer.git", "bd54184dae19d5117534c6e6885fa5abd1fe5da4", [ref: "typed-gen-server"]},
+  "gradualizer": {:git, "https://github.com/josefs/Gradualizer.git", "6e89b4e1cd489637a848cc5ca55058c8a241bf7d", [ref: "6e89b4e"]},
 }

--- a/examples/typed_gen_server/mix.lock
+++ b/examples/typed_gen_server/mix.lock
@@ -2,5 +2,4 @@
   "dialyxir": {:hex, :dialyxir, "1.1.0", "c5aab0d6e71e5522e77beff7ba9e08f8e02bad90dfbeffae60eaf0cb47e29488", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "07ea8e49c45f15264ebe6d5b93799d4dd56a44036cf42d0ad9c960bc266c0b9a"},
   "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
   "gradualizer": {:git, "https://github.com/erszcz/Gradualizer.git", "bd54184dae19d5117534c6e6885fa5abd1fe5da4", [ref: "typed-gen-server"]},
-  "gradualizer_ex": {:git, "https://github.com/erszcz/gradualizer-ex.git", "dc64f484c83a5ce286696fb79756577a1b9853f5", [branch: "rs/wip"]},
 }

--- a/lib/gradient/type_annotation.ex
+++ b/lib/gradient/type_annotation.ex
@@ -8,7 +8,7 @@ defmodule Gradient.TypeAnnotation do
   defp annotate(type_op, expr, type) do
     erlang_type = elixir_type_to_erlang(type)
     # IO.inspect(erlang_type, label: "erlang type")
-    {type_op, [], [expr, Macro.to_string(erlang_type)]}
+    {type_op, [], [expr, erlang_type]}
     # |> IO.inspect(label: "annotation node")
   end
 

--- a/lib/gradient/typed_server/compile_hooks.ex
+++ b/lib/gradient/typed_server/compile_hooks.ex
@@ -17,11 +17,6 @@ defmodule Gradient.TypedServer.CompileHooks do
   end
 
   def __on_definition__(env, _kind, name, args, _guards, body) do
-    # if name == :handle do
-    #  # IO.inspect({name, env}, limit: :infinity)
-    #  #{env.module, Module.get_attribute(env.module, :spec)} |> IO.inspect()
-    # end
-
     request_handler = Module.get_attribute(env.module, :request_handler, :handle)
 
     case request_handler do

--- a/lib/gradient/typed_server/compile_hooks.ex
+++ b/lib/gradient/typed_server/compile_hooks.ex
@@ -17,10 +17,10 @@ defmodule Gradient.TypedServer.CompileHooks do
   end
 
   def __on_definition__(env, _kind, name, args, _guards, body) do
-    if name == :handle do
-      # IO.inspect({name, env}, limit: :infinity)
-      IO.inspect({env.module, Module.get_attribute(env.module, :spec)})
-    end
+    # if name == :handle do
+    #  # IO.inspect({name, env}, limit: :infinity)
+    #  #{env.module, Module.get_attribute(env.module, :spec)} |> IO.inspect()
+    # end
 
     request_handler = Module.get_attribute(env.module, :request_handler, :handle)
 


### PR DESCRIPTION
This PR updates the TypedServer demo to use current Gradient (instead of GradualizerEx) and makes sure it's runnable as is without any glitches.

The demo as of this PR still relies on two non-standard features in upstream Gradualizer:
- https://github.com/josefs/Gradualizer/pull/391
- https://github.com/josefs/Gradualizer/pull/392

The aim is to get rid of any customisations and either make the demo conform to the upstream feature set or merge the necessary changes upstream.