### PR TITLE
Support location specifying in pipe op

### DIFF
--- a/lib/gradient/ast_specifier.ex
+++ b/lib/gradient/ast_specifier.ex
@@ -590,7 +590,7 @@ defmodule Gradient.AstSpecifier do
   end
 
   @doc """
-    Update location in call args with the support to the pipe operator.
+  Update location in call args with the support to the pipe operator.
   """
   @spec call_args_mapper([abstract_expr()], tokens(), abstract_expr(), options()) ::
           {options, [abstract_expr]}

--- a/lib/gradient/ast_specifier.ex
+++ b/lib/gradient/ast_specifier.ex
@@ -21,7 +21,7 @@ defmodule Gradient.AstSpecifier do
   @type abstract_expr :: Types.abstract_expr()
 
   # Expressions that could have missing location
-  @lineless_forms [:atom, :char, :float, :integer, :string, :bin, :cons]
+  @lineless_forms [:atom, :char, :float, :integer, :string, :bin, :cons, :tuple]
 
   # Api
 
@@ -523,8 +523,7 @@ defmodule Gradient.AstSpecifier do
   @spec map_element_mapper(tuple(), tokens(), options()) :: {tuple(), tokens()}
   def map_element_mapper({field, anno, key, value}, tokens, opts)
       when field in [:map_field_assoc, :map_field_exact] do
-    line = :erl_anno.line(anno)
-    opts = Keyword.put(opts, :line, line)
+    {:ok, _, anno, opts, _} = get_line(anno, opts)
 
     {key, tokens} = mapper(key, tokens, opts)
     {value, tokens} = mapper(value, tokens, opts)
@@ -826,5 +825,5 @@ defmodule Gradient.AstSpecifier do
     elem(expr, 0) in @lineless_forms
   end
 
-  defp clear_location(form), do: put_elem(form, 1, :erl_anno.set_line(0, elem(form, 1)))
+  defp clear_location(arg), do: :erl_parse.map_anno(&:erl_anno.set_line(0, &1), arg)
 end

--- a/lib/gradient/ast_specifier.ex
+++ b/lib/gradient/ast_specifier.ex
@@ -5,43 +5,6 @@ defmodule Gradient.AstSpecifier do
   it to forms that cannot be produced from Elixir directly.
 
   FIXME Optimize tokens searching. Find out why some tokens are dropped 
-
-  NOTE Mapper implements:
-  - function [x]
-  - fun [x] 
-  - fun @spec [x]
-  - clause [x] 
-  - case [x]
-  - block [X] 
-  - pipe [x]
-  - call [x] (remote [X])
-  - match [x]
-  - op [x]
-  - integer [x]
-  - float [x]
-  - string [x]
-  - charlist [x]
-  - tuple [X]
-  - var [X]
-  - list [X] 
-  - keyword [X]
-  - binary [X] 
-  - map [X] 
-  - try [x] 
-  - receive [X] 
-  - record [X] elixir don't use it record_field, record_index, record_pattern, record
-  - named_fun [ ] is named_fun used by elixir? 
-
-  NOTE Elixir expressions to handle or test:
-  - list comprehension [X]
-  - binary [X]
-  - maps [X]
-  - struct [X]
-  - pipe [X] TODO decide how to search for line in reversed form order
-  - range [X] 
-  - receive [X] 
-  - record [X] 
-  - guards [X]
   """
 
   import Gradient.Tokens

--- a/test/gradient/ast_specifier_test.exs
+++ b/test/gradient/ast_specifier_test.exs
@@ -566,13 +566,13 @@ defmodule Gradient.AstSpecifierTest do
                   [
                     {:call, 4, {:remote, 4, {:atom, 4, Enum}, {:atom, 4, :filter}},
                      [
-                       {:cons, 4, {:integer, 4, 1},
-                        {:cons, 4,
+                       {:cons, 3, {:integer, 3, 1},
+                        {:cons, 3,
                          {
                            :integer,
-                           4,
+                           3,
                            2
-                         }, {:cons, 4, {:integer, 4, 3}, {nil, 4}}}},
+                         }, {:cons, 3, {:integer, 3, 3}, {nil, 3}}}},
                        {:fun, 4,
                         {:clauses,
                          [

--- a/test/gradient/ast_specifier_test.exs
+++ b/test/gradient/ast_specifier_test.exs
@@ -10,6 +10,16 @@ defmodule Gradient.AstSpecifierTest do
     {:ok, state}
   end
 
+  describe "specifying expression" do
+    for {name, args, expected} <- Gradient.AstData.ast_data() do
+      test "#{name}" do
+        {ast, tokens, opts} = unquote(Macro.escape(args))
+        expected = unquote(Macro.escape(expected))
+        assert expected == elem(AstSpecifier.mapper(ast, tokens, opts), 0)
+      end
+    end
+  end
+
   describe "run_mappers/2" do
     test "messy test on simple_app" do
       {tokens, ast} = example_data()

--- a/test/gradient/ast_specifier_test.exs
+++ b/test/gradient/ast_specifier_test.exs
@@ -3,6 +3,7 @@ defmodule Gradient.AstSpecifierTest do
   doctest Gradient.AstSpecifier
 
   alias Gradient.AstSpecifier
+  alias Gradient.AstData
 
   import Gradient.TestHelpers
 
@@ -11,11 +12,14 @@ defmodule Gradient.AstSpecifierTest do
   end
 
   describe "specifying expression" do
-    for {name, args, expected} <- Gradient.AstData.ast_data() do
+    for {name, args, expected} <- AstData.ast_data() do
       test "#{name}" do
         {ast, tokens, opts} = unquote(Macro.escape(args))
-        expected = unquote(Macro.escape(expected))
-        assert expected == elem(AstSpecifier.mapper(ast, tokens, opts), 0)
+        expected = AstData.normalize_expression(unquote(Macro.escape(expected)))
+
+        actual = AstData.normalize_expression(elem(AstSpecifier.mapper(ast, tokens, opts), 0))
+
+        assert expected == actual
       end
     end
   end

--- a/test/support/ast_data.ex
+++ b/test/support/ast_data.ex
@@ -38,23 +38,23 @@ defmodule Gradient.AstData do
         "a"
         |> is_atom()
       end, __ENV__.line},
-     {:block, 11,
+     {:block, 22,
       [
-        {:call, 14, {:remote, 14, {:atom, 14, :erlang}, {:atom, 14, :is_atom}},
-         [{:integer, 13, 1}]},
-        {:call, 17, {:remote, 17, {:atom, 17, :erlang}, {:atom, 17, :is_atom}},
-         [{:cons, 16, {:integer, 16, 49}, {nil, 16}}]},
-        {:call, 20, {:remote, 20, {:atom, 20, :erlang}, {:atom, 20, :is_atom}},
-         [{:atom, 19, :ok}]},
-        {:call, 23, {:remote, 23, {:atom, 23, :erlang}, {:atom, 23, :is_atom}},
+        {:call, 24, {:remote, 24, {:atom, 24, :erlang}, {:atom, 24, :is_atom}},
+         [{:integer, 23, 1}]},
+        {:call, 27, {:remote, 27, {:atom, 27, :erlang}, {:atom, 27, :is_atom}},
+         [{:cons, 26, {:integer, 26, 49}, {nil, 26}}]},
+        {:call, 30, {:remote, 30, {:atom, 30, :erlang}, {:atom, 30, :is_atom}},
+         [{:atom, 29, :ok}]},
+        {:call, 33, {:remote, 33, {:atom, 33, :erlang}, {:atom, 33, :is_atom}},
          [
-           {:cons, 22, {:integer, 22, 1},
-            {:cons, 22, {:integer, 22, 2}, {:cons, 22, {:integer, 22, 3}, {nil, 22}}}}
+           {:cons, 32, {:integer, 32, 1},
+            {:cons, 32, {:integer, 32, 2}, {:cons, 32, {:integer, 32, 3}, {nil, 32}}}}
          ]},
-        {:call, 26, {:remote, 26, {:atom, 26, :erlang}, {:atom, 26, :is_atom}},
-         [{:tuple, 25, [{:integer, 25, 1}, {:integer, 25, 2}, {:integer, 25, 3}]}]},
-        {:call, 29, {:remote, 29, {:atom, 29, :erlang}, {:atom, 29, :is_atom}},
-         [{:bin, 28, [{:bin_element, 28, {:string, 28, 'a'}, :default, :default}]}]}
+        {:call, 36, {:remote, 36, {:atom, 36, :erlang}, {:atom, 36, :is_atom}},
+         [{:tuple, 35, [{:integer, 35, 1}, {:integer, 35, 2}, {:integer, 35, 3}]}]},
+        {:call, 39, {:remote, 39, {:atom, 39, :erlang}, {:atom, 39, :is_atom}},
+         [{:bin, 38, [{:bin_element, 38, {:string, 38, 'a'}, :default, :default}]}]}
       ]}}
   end
 
@@ -69,14 +69,84 @@ defmodule Gradient.AstData do
       [{:integer, 56, 1}, {:atom, 55, :ok}]}}
   end
 
+  defp complex_list_pipe do
+    {__ENV__.function,
+     {__ENV__.line,
+      elixir_to_ast do
+        [
+          {1, %{a: 1}},
+          {2, %{a: 2}}
+        ]
+        |> Enum.map(&elem(&1, 0))
+      end, __ENV__.line},
+     {:call, 80, {:remote, 80, {:atom, 80, Enum}, {:atom, 80, :map}},
+      [
+        {:cons, 76,
+         {:tuple, 77,
+          [
+            {:integer, 77, 1},
+            {:map, 77, [{:map_field_assoc, 77, {:atom, 77, :a}, {:integer, 77, 1}}]}
+          ]},
+         {:cons, 77,
+          {:tuple, 78,
+           [
+             {:integer, 78, 2},
+             {:map, 78, [{:map_field_assoc, 78, {:atom, 78, :a}, {:integer, 78, 2}}]}
+           ]}, {nil, 77}}},
+        {:fun, 80,
+         {:clauses,
+          [
+            {:clause, 80, [{:var, 0, :_@1}], [],
+             [
+               {:call, 80, {:remote, 80, {:atom, 80, :erlang}, {:atom, 80, :element}},
+                [{:integer, 80, 1}, {:var, 0, :_@1}]}
+             ]}
+          ]}}
+      ]}}
+  end
+
+  defp complex_tuple_pipe do
+    {__ENV__.function,
+     {__ENV__.line,
+      elixir_to_ast do
+        {
+          {1, %{a: 1}},
+          {2, %{a: 2}}
+        }
+        |> Tuple.to_list()
+      end, __ENV__.line},
+     {:call, 119, {:remote, 119, {:atom, 119, :erlang}, {:atom, 119, :tuple_to_list}},
+      [
+        {:tuple, 115,
+         [
+           {:tuple, 116,
+            [
+              {:integer, 116, 1},
+              {:map, 116, [{:map_field_assoc, 116, {:atom, 116, :a}, {:integer, 116, 1}}]}
+            ]},
+           {:tuple, 117,
+            [
+              {:integer, 117, 2},
+              {:map, 117, [{:map_field_assoc, 117, {:atom, 117, :a}, {:integer, 117, 2}}]}
+            ]}
+         ]}
+      ]}}
+  end
+
   @spec ast_data() :: [
-          {atom(), {Types.abstract_expr(), Types.tokens(), Types.options()}, tuple()}
+          {atom(), {Types.abstract_expr(), Types.tokens(), Types.options()},
+           Types.abstract_expr()}
         ]
   def ast_data do
-    [pipe(), pipe_with_fun_converted_to_erl_equivalent()]
+    [
+      pipe(),
+      pipe_with_fun_converted_to_erl_equivalent(),
+      complex_list_pipe(),
+      complex_tuple_pipe()
+    ]
     |> Enum.map(fn {{name, _}, {start_line, ast, end_line}, expected} ->
-      tokens = Gradient.Tokens.drop_tokens_to_line(@tokens, start_line)
-      {name, {ast, tokens, [line: start_line, end_line: end_line]}, expected}
+      tokens = Gradient.Tokens.drop_tokens_to_line(@tokens, start_line + 1)
+      {name, {ast, tokens, [line: start_line + 1, end_line: end_line]}, expected}
     end)
   end
 

--- a/test/support/ast_data.ex
+++ b/test/support/ast_data.ex
@@ -1,0 +1,59 @@
+defmodule Gradient.AstData do
+  require Gradient.Debug
+  import Gradient.Debug, only: [elixir_to_ast: 1]
+  import Gradient.TestHelpers
+  alias Gradient.Types
+
+  @tokens __ENV__.file |> load_tokens()
+
+  defp pipe do
+    {__ENV__.function,
+     {__ENV__.line,
+      elixir_to_ast do
+        1
+        |> is_atom()
+
+        '1'
+        |> is_atom()
+
+        :ok
+        |> is_atom()
+
+        [1, 2, 3]
+        |> is_atom()
+
+        {1, 2, 3}
+        |> is_atom()
+
+        "a"
+        |> is_atom()
+      end, __ENV__.line},
+     {:block, 11,
+      [
+        {:call, 14, {:remote, 14, {:atom, 14, :erlang}, {:atom, 14, :is_atom}},
+         [{:integer, 13, 1}]},
+        {:call, 17, {:remote, 17, {:atom, 17, :erlang}, {:atom, 17, :is_atom}},
+         [{:cons, 16, {:integer, 16, 49}, {nil, 16}}]},
+        {:call, 20, {:remote, 20, {:atom, 20, :erlang}, {:atom, 20, :is_atom}},
+         [{:atom, 19, :ok}]},
+        {:call, 23, {:remote, 23, {:atom, 23, :erlang}, {:atom, 23, :is_atom}},
+         [
+           {:cons, 22, {:integer, 22, 1},
+            {:cons, 22, {:integer, 22, 2}, {:cons, 22, {:integer, 22, 3}, {nil, 22}}}}
+         ]},
+        {:call, 26, {:remote, 26, {:atom, 26, :erlang}, {:atom, 26, :is_atom}},
+         [{:tuple, 25, [{:integer, 25, 1}, {:integer, 25, 2}, {:integer, 25, 3}]}]},
+        {:call, 29, {:remote, 29, {:atom, 29, :erlang}, {:atom, 29, :is_atom}},
+         [{:bin, 28, [{:bin_element, 28, {:string, 28, 'a'}, :default, :default}]}]}
+      ]}}
+  end
+
+  @spec ast_data() :: [{Types.abstract_expr(), Types.tokens(), Types.options()}]
+  def ast_data do
+    [pipe()]
+    |> Enum.map(fn {{name, _}, {start_line, ast, end_line}, expected} ->
+      tokens = Gradient.Tokens.drop_tokens_to_line(@tokens, start_line)
+      {name, {ast, tokens, [line: start_line, end_line: end_line]}, expected}
+    end)
+  end
+end

--- a/test/support/ast_data.ex
+++ b/test/support/ast_data.ex
@@ -48,9 +48,30 @@ defmodule Gradient.AstData do
       ]}}
   end
 
-  @spec ast_data() :: [{Types.abstract_expr(), Types.tokens(), Types.options()}]
+  defp pipe_with_fun_converted_to_erl_equivalent do
+    {__ENV__.function,
+     {__ENV__.line,
+      elixir_to_ast do
+        :ok
+        |> elem(0)
+      end, __ENV__.line},
+     {:call, 56, {:remote, 56, {:atom, 56, :erlang}, {:atom, 56, :element}},
+      [{:integer, 56, 1}, {:atom, 55, :ok}]}}
+  end
+
+  defp example do
+    {__ENV__.function,
+     {__ENV__.line,
+      elixir_to_ast do
+        :ok
+      end, __ENV__.line}, _expected = {}}
+  end
+
+  @spec ast_data() :: [
+          {atom(), {Types.abstract_expr(), Types.tokens(), Types.options()}, tuple()}
+        ]
   def ast_data do
-    [pipe()]
+    [pipe(), pipe_with_fun_converted_to_erl_equivalent()]
     |> Enum.map(fn {{name, _}, {start_line, ast, end_line}, expected} ->
       tokens = Gradient.Tokens.drop_tokens_to_line(@tokens, start_line)
       {name, {ast, tokens, [line: start_line, end_line: end_line]}, expected}

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -29,6 +29,13 @@ defmodule Gradient.TestHelpers do
     {tokens, ast}
   end
 
+  def load_tokens(path) do
+    with {:ok, code} <- File.read(path),
+         {:ok, tokens} <- :elixir.string_to_tokens(String.to_charlist(code), 1, 1, path, []) do
+      tokens
+    end
+  end
+
   @spec example_data() :: {T.tokens(), T.forms()}
   def example_data() do
     beam_path = Path.join(@examples_build_path, "Elixir.SimpleApp.beam") |> String.to_charlist()


### PR DESCRIPTION
This resolves #9 and finally handles specifying location with the tokens in the pipe operator.

### Before
![image](https://user-images.githubusercontent.com/15876592/161246152-8e914b70-4647-4b74-a6f3-7a707121bc19.png)

### Now
![image](https://user-images.githubusercontent.com/15876592/161246199-c0817a50-7a60-49aa-95e9-15f328261165.png)

### Solution

Added a check to the `call` mapper if the first token is a `|>`. If true and if the first `call` arg is a lineless expression (an expression that could be without location) then the line in `opts` is set to 0. Thus the tokens before this `call` line are not dropped and the lineless expression can find the correct line in tokens.

#### Problem

Conversion of some Elixir functions to the Erlang functions that take the result as second arg instead of the first one.
For example, the `elem(result, pos)` function is converted to the Erlang `element(pos, result)`.

It is solved by detecting when the call is to function from the`:erlang` module and if it is, the first and second args are swapped. After specifying lines the correct args order is restored.

### New testing format for specifying expressions
This PR proposed a new testing format for specifying expressions similar to the one for the type pretty-printer. Test cases can be defined in the `Gradient.AstData` module. Each case contains the input values and the expected result. Thanks to this the expression specification can be tested without adding a new `.ex` file and compiling it.

I am still thinking about how to make it more pretty and flexible.