### PR TITLE
Ensure that app compile dir is added to code 

### DIFF
--- a/examples/simple_umbrella_app/.formatter.exs
+++ b/examples/simple_umbrella_app/.formatter.exs
@@ -1,0 +1,5 @@
+# Used by "mix format"
+[
+  inputs: ["mix.exs", "config/*.exs"],
+  subdirectories: ["apps/*"]
+]

--- a/examples/simple_umbrella_app/.gitignore
+++ b/examples/simple_umbrella_app/.gitignore
@@ -1,0 +1,23 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Temporary files, for example, from tests.
+/tmp/

--- a/examples/simple_umbrella_app/README.md
+++ b/examples/simple_umbrella_app/README.md
@@ -1,0 +1,4 @@
+# SimpleUmbrellaApp
+
+**TODO: Add description**
+

--- a/examples/simple_umbrella_app/apps/app_a/.formatter.exs
+++ b/examples/simple_umbrella_app/apps/app_a/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/examples/simple_umbrella_app/apps/app_a/.gitignore
+++ b/examples/simple_umbrella_app/apps/app_a/.gitignore
@@ -1,0 +1,26 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+app_a-*.tar
+
+# Temporary files, for example, from tests.
+/tmp/

--- a/examples/simple_umbrella_app/apps/app_a/README.md
+++ b/examples/simple_umbrella_app/apps/app_a/README.md
@@ -1,0 +1,21 @@
+# AppA
+
+**TODO: Add description**
+
+## Installation
+
+If [available in Hex](https://hex.pm/docs/publish), the package can be installed
+by adding `app_a` to your list of dependencies in `mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:app_a, "~> 0.1.0"}
+  ]
+end
+```
+
+Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
+and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
+be found at [https://hexdocs.pm/app_a](https://hexdocs.pm/app_a).
+

--- a/examples/simple_umbrella_app/apps/app_a/lib/app_a.ex
+++ b/examples/simple_umbrella_app/apps/app_a/lib/app_a.ex
@@ -1,0 +1,18 @@
+defmodule AppA do
+  @moduledoc """
+  Documentation for `AppA`.
+  """
+
+  @doc """
+  Hello world.
+
+  ## Examples
+
+      iex> AppA.hello()
+      :world
+
+  """
+  def hello do
+    :world
+  end
+end

--- a/examples/simple_umbrella_app/apps/app_a/mix.exs
+++ b/examples/simple_umbrella_app/apps/app_a/mix.exs
@@ -1,0 +1,33 @@
+defmodule AppA.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :app_a,
+      version: "0.1.0",
+      build_path: "../../_build",
+      config_path: "../../config/config.exs",
+      deps_path: "../../deps",
+      lockfile: "../../mix.lock",
+      elixir: "~> 1.12",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      # {:dep_from_hexpm, "~> 0.3.0"},
+      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
+      # {:sibling_app_in_umbrella, in_umbrella: true}
+    ]
+  end
+end

--- a/examples/simple_umbrella_app/apps/app_a/test/app_a_test.exs
+++ b/examples/simple_umbrella_app/apps/app_a/test/app_a_test.exs
@@ -1,0 +1,8 @@
+defmodule AppATest do
+  use ExUnit.Case
+  doctest AppA
+
+  test "greets the world" do
+    assert AppA.hello() == :world
+  end
+end

--- a/examples/simple_umbrella_app/apps/app_a/test/test_helper.exs
+++ b/examples/simple_umbrella_app/apps/app_a/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/examples/simple_umbrella_app/apps/app_b/.formatter.exs
+++ b/examples/simple_umbrella_app/apps/app_b/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/examples/simple_umbrella_app/apps/app_b/.gitignore
+++ b/examples/simple_umbrella_app/apps/app_b/.gitignore
@@ -1,0 +1,26 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+app_b-*.tar
+
+# Temporary files, for example, from tests.
+/tmp/

--- a/examples/simple_umbrella_app/apps/app_b/README.md
+++ b/examples/simple_umbrella_app/apps/app_b/README.md
@@ -1,0 +1,21 @@
+# AppB
+
+**TODO: Add description**
+
+## Installation
+
+If [available in Hex](https://hex.pm/docs/publish), the package can be installed
+by adding `app_b` to your list of dependencies in `mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:app_b, "~> 0.1.0"}
+  ]
+end
+```
+
+Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
+and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
+be found at [https://hexdocs.pm/app_b](https://hexdocs.pm/app_b).
+

--- a/examples/simple_umbrella_app/apps/app_b/lib/app_b.ex
+++ b/examples/simple_umbrella_app/apps/app_b/lib/app_b.ex
@@ -1,0 +1,18 @@
+defmodule AppB do
+  @moduledoc """
+  Documentation for `AppB`.
+  """
+
+  @doc """
+  Hello world.
+
+  ## Examples
+
+      iex> AppB.hello()
+      :world
+
+  """
+  def hello do
+    AppA.hello()
+  end
+end

--- a/examples/simple_umbrella_app/apps/app_b/mix.exs
+++ b/examples/simple_umbrella_app/apps/app_b/mix.exs
@@ -1,0 +1,33 @@
+defmodule AppB.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :app_b,
+      version: "0.1.0",
+      build_path: "../../_build",
+      config_path: "../../config/config.exs",
+      deps_path: "../../deps",
+      lockfile: "../../mix.lock",
+      elixir: "~> 1.12",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [{:app_a, in_umbrella: true}
+      # {:dep_from_hexpm, "~> 0.3.0"},
+      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
+      # {:sibling_app_in_umbrella, in_umbrella: true}
+    ]
+  end
+end

--- a/examples/simple_umbrella_app/apps/app_b/test/app_b_test.exs
+++ b/examples/simple_umbrella_app/apps/app_b/test/app_b_test.exs
@@ -1,0 +1,8 @@
+defmodule AppBTest do
+  use ExUnit.Case
+  doctest AppB
+
+  test "greets the world" do
+    assert AppB.hello() == :world
+  end
+end

--- a/examples/simple_umbrella_app/apps/app_b/test/test_helper.exs
+++ b/examples/simple_umbrella_app/apps/app_b/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/examples/simple_umbrella_app/config/config.exs
+++ b/examples/simple_umbrella_app/config/config.exs
@@ -1,0 +1,18 @@
+# This file is responsible for configuring your umbrella
+# and **all applications** and their dependencies with the
+# help of the Config module.
+#
+# Note that all applications in your umbrella share the
+# same configuration and dependencies, which is why they
+# all use the same configuration file. If you want different
+# configurations or dependencies per app, it is best to
+# move said applications out of the umbrella.
+import Config
+
+# Sample configuration:
+#
+#     config :logger, :console,
+#       level: :info,
+#       format: "$date $time [$level] $metadata$message\n",
+#       metadata: [:user_id]
+#

--- a/examples/simple_umbrella_app/mix.exs
+++ b/examples/simple_umbrella_app/mix.exs
@@ -1,0 +1,21 @@
+defmodule SimpleUmbrellaApp.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      apps_path: "apps",
+      version: "0.1.0",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Dependencies listed here are available only for this
+  # project and cannot be accessed from applications inside
+  # the apps folder.
+  #
+  # Run "mix help deps" for examples and options.
+  defp deps do
+    [{:gradient, path: "../../"}]
+  end
+end

--- a/examples/simple_umbrella_app/mix.lock
+++ b/examples/simple_umbrella_app/mix.lock
@@ -1,0 +1,3 @@
+%{
+  "gradualizer": {:git, "https://github.com/josefs/Gradualizer.git", "9e629ade733780113973fe672a51d9650ed0cd86", [ref: "9e629ad"]},
+}


### PR DESCRIPTION
It refers to #75 and should fix not importing app modules to the `gradualizer_db`.

Gradualizer can load deps automatically when the application starts. The paths are taken from `:code`, and it turns out that the app compile path could be missing there. Thus now we ensure that that app path is not missing.