### PR TITLE
Fix crashes on ExDoc

### DIFF
--- a/lib/gradient/ast_specifier.ex
+++ b/lib/gradient/ast_specifier.ex
@@ -513,7 +513,7 @@ defmodule Gradient.AstSpecifier do
 
       gs, {ags, ts} ->
         Logger.error("Unsupported guards format #{inspect(gs)}")
-        {gs ++ ags, ts}
+        {[gs | ags], ts}
     end)
   end
 

--- a/lib/gradient/ast_specifier.ex
+++ b/lib/gradient/ast_specifier.ex
@@ -507,12 +507,12 @@ defmodule Gradient.AstSpecifier do
 
   def guards_mapper(guards, tokens, opts) do
     List.foldl(guards, {[], tokens}, fn
-      [guard], {gs, tokens} ->
-        {g, ts} = mapper(guard, tokens, opts)
-        {[[g] | gs], ts}
-
       gs, {ags, ts} ->
-        Logger.error("Unsupported guards format #{inspect(gs)}")
+        {gs, _} = List.foldl(gs, {[], ts}, fn
+          g, {conjunction, ts} ->
+            {g, ts} = mapper(g, ts, opts)
+            {[g | conjunction], ts}
+        end)
         {[gs | ags], ts}
     end)
   end

--- a/lib/gradient/elixir_fmt.ex
+++ b/lib/gradient/elixir_fmt.ex
@@ -254,7 +254,7 @@ defmodule Gradient.ElixirFmt do
     {:ok, type_color} = Keyword.fetch(colors, :type)
 
     fn type ->
-      IO.ANSI.format([type_color, fmt.(type)], use_colors)
+      [IO.ANSI.format([type_color, fmt.(type)], use_colors)]
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule Gradient.MixProject do
   # Run "mix help deps" to learn about dependencies.
   def deps do
     [
-      {:gradualizer, github: "josefs/Gradualizer", ref: "9e629ad", manager: :rebar3},
+      {:gradualizer, github: "josefs/Gradualizer", ref: "a72e7f0", manager: :rebar3},
       # {:gradualizer, path: "../Gradualizer/", manager: :rebar3},
       {:dialyxir, "~> 1.0", only: [:dev], runtime: false}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
   "dialyxir": {:hex, :dialyxir, "1.1.0", "c5aab0d6e71e5522e77beff7ba9e08f8e02bad90dfbeffae60eaf0cb47e29488", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "07ea8e49c45f15264ebe6d5b93799d4dd56a44036cf42d0ad9c960bc266c0b9a"},
   "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
-  "gradualizer": {:git, "https://github.com/josefs/Gradualizer.git", "9e629ade733780113973fe672a51d9650ed0cd86", [ref: "9e629ad"]},
+  "gradualizer": {:git, "https://github.com/josefs/Gradualizer.git", "a72e7f0b7e55f235fdaa944340a13e0e41bc5ee3", [ref: "a72e7f0"]},
 }


### PR DESCRIPTION
This partially addresses #78. Fixing the initial `IO.ANSI.format()` issue uncovers more crashes which also have to be taken care of.