### PR TITLE
Support typechecking for erlang files from  `src/` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,11 @@ gradient-*.tar
 # Temporary files, for example, from tests.
 /tmp/
 
-# Beam files compiled from examples
+# Elixir beam files compiled from examples
 test/examples/_build/
+
+# Erlang beam files compiled from examples
+test/examples/erlang/_build/
 
 # MacOS DS_Store
 .DS_Store

--- a/test/examples/erlang/test.erl
+++ b/test/examples/erlang/test.erl
@@ -1,0 +1,9 @@
+-module(test).
+
+-export([positive/1]).
+
+-spec positive(integer()) -> ok | error.
+positive(A) when A > 0 ->
+    ok;
+positive(_) ->
+    error.

--- a/test/examples/erlang/test_err.erl
+++ b/test/examples/erlang/test_err.erl
@@ -1,0 +1,9 @@
+-module(test_err).
+
+-export([positive/1]).
+
+-spec positive(integer()) -> integer().
+positive(A) when A > 0 ->
+    ok;
+positive(_) ->
+    error.

--- a/test/gradient_test.exs
+++ b/test/gradient_test.exs
@@ -1,4 +1,31 @@
 defmodule GradientTest do
   use ExUnit.Case
   doctest Gradient
+
+  import Gradient.TestHelpers
+  import ExUnit.CaptureIO
+
+  test "typecheck erlang beam" do
+    # typecheck file with errors
+    path = "test/examples/erlang/_build/test_err.beam"
+    erl_path = "test/examples/erlang/test_err.erl"
+    io_data = capture_io(fn -> assert :error = Gradient.type_check_file(path) end)
+    assert String.contains?(io_data, erl_path)
+    # typecheck correct file
+    capture_io(fn ->
+      assert :ok = Gradient.type_check_file("test/examples/erlang/_build/test.beam")
+    end)
+  end
+
+  test "typecheck elixir beam" do
+    # typecheck file with errors
+    path = "test/examples/_build/Elixir.WrongRet.beam"
+    ex_path = "test/examples/type/wrong_ret.ex"
+    io_data = capture_io(fn -> assert :error = Gradient.type_check_file(path) end)
+    assert String.contains?(io_data, ex_path)
+    # typecheck correct file
+    capture_io(fn ->
+      assert :ok = Gradient.type_check_file("test/examples/_build/Elixir.Basic.beam")
+    end)
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,6 @@
 defmodule ExamplesCompiler do
   @build_path "test/examples/_build/"
+  @erl_build_path "test/examples/erlang/_build/"
 
   @version_step 0.01
 
@@ -18,6 +19,20 @@ defmodule ExamplesCompiler do
 
         Kernel.ParallelCompiler.compile_to_path(paths, @build_path)
         :ok
+
+      _ ->
+        :error
+    end
+  end
+
+  def erl_compile(pattern) do
+    case File.mkdir(@erl_build_path) do
+      :ok ->
+        pattern
+        |> Path.wildcard()
+        |> Enum.each(fn p ->
+          :compile.file(to_charlist(p), [:debug_info, {:outdir, to_charlist(@erl_build_path)}])
+        end)
 
       _ ->
         :error
@@ -57,5 +72,7 @@ end
 
 ExamplesCompiler.compile("test/examples/**/*.ex")
 exlcude = ExamplesCompiler.excluded_version_tags()
+
+ExamplesCompiler.erl_compile("test/examples/erlang/**/*.erl")
 
 ExUnit.start(exclude: exlcude)


### PR DESCRIPTION
The beams compiled from the Erlang files should be routed directly to the Gradualizer and errors should be formatted also by Gradualizer. This PR adds a check for a file extension type and skips Gradient processing if it is an Erlang file. 