### PR TITLE
Fix manual type annotations

### DIFF
--- a/lib/gradient/ast_specifier.ex
+++ b/lib/gradient/ast_specifier.ex
@@ -320,7 +320,8 @@ defmodule Gradient.AstSpecifier do
         _opts
       )
       when name_atom in [:"::", :":::"] do
-    # unwrap string from binary for correct type annotation matching
+    # unwrap string from binary for correct type annotation matching.
+    # see Gradient.TypeAnnotation.Type.to_erlang/1 for a use case.
     {:call, anno, name, [expr, val]}
     |> pass_tokens(tokens)
   end

--- a/lib/gradient/elixir_expr.ex
+++ b/lib/gradient/elixir_expr.ex
@@ -495,7 +495,5 @@ defmodule Gradient.ElixirExpr do
   defp pp_name({:remote, _, {:atom, _, m}, {:atom, _, n}}),
     do: ElixirFmt.parse_module(m) <> to_string(n)
 
-  defp pp_name({:atom, _, :":::"}), do: "__assert_type__"
-  defp pp_name({:atom, _, :"::"}), do: "__annotate_type__"
   defp pp_name({:atom, _, n}), do: to_string(n)
 end

--- a/lib/gradient/elixir_expr.ex
+++ b/lib/gradient/elixir_expr.ex
@@ -495,5 +495,7 @@ defmodule Gradient.ElixirExpr do
   defp pp_name({:remote, _, {:atom, _, m}, {:atom, _, n}}),
     do: ElixirFmt.parse_module(m) <> to_string(n)
 
+  defp pp_name({:atom, _, :":::"}), do: "__assert_type__"
+  defp pp_name({:atom, _, :"::"}), do: "__annotate_type__"
   defp pp_name({:atom, _, n}), do: to_string(n)
 end

--- a/lib/gradient/elixir_fmt.ex
+++ b/lib/gradient/elixir_fmt.ex
@@ -68,7 +68,14 @@ defmodule Gradient.ElixirFmt do
   @impl Gradient.Fmt
   def format_type_error({:type_error, expression, actual_type, expected_type}, opts)
       when is_tuple(expression) do
-    format_expr_type_error(expression, actual_type, expected_type, opts)
+    case expression do
+      {:call, _, {:atom, _, assert_or_annotate}, [inner_expr, _]}
+      when assert_or_annotate in [:"::", :":::"] ->
+        format_expr_type_error(inner_expr, actual_type, expected_type, opts)
+
+      _ ->
+        format_expr_type_error(expression, actual_type, expected_type, opts)
+    end
   end
 
   def format_type_error({:nonexhaustive, anno, example}, opts) do

--- a/lib/gradient/type_annotation.ex
+++ b/lib/gradient/type_annotation.ex
@@ -13,7 +13,7 @@ defmodule Gradient.TypeAnnotation do
         {{:., _, [{:__aliases__, _, path}, name]}, _, args} ->
           ## TODO: this is unsafe, but OTOH there's no guarantee that a remote/invalid module
           ## will be available to load locally or its name already loaded at check time...
-          erlang_mod = "Elixir.#{Enum.join(path, ".")}" |> String.to_atom()
+          erlang_mod = Module.concat([Elixir | path])
           erlang_args = for a <- args, do: to_erlang_ast(a)
           {:call, 0, {:remote, 0, {:atom, 0, erlang_mod}, {:atom, 0, name}}, erlang_args}
 

--- a/lib/gradient/type_annotation.ex
+++ b/lib/gradient/type_annotation.ex
@@ -21,7 +21,6 @@ defmodule Gradient.TypeAnnotation do
           erlang_args = for a <- args, do: to_erlang_ast(a)
           {:call, 0, {:atom, 0, name}, erlang_args}
 
-
         a when is_atom(a) ->
           {:atom, 0, a}
       end

--- a/test/examples/annotations.ex
+++ b/test/examples/annotations.ex
@@ -1,0 +1,24 @@
+defmodule Annotations.ShouldPass do
+  use Gradient.TypeAnnotation
+
+  @spec f(list(integer())) :: integer()
+  def f(l) do
+    l |> assert_type(nonempty_list()) |> hd()
+  end
+end
+
+defmodule Annotations.ShouldFail.NoAnno do
+  @spec f(list(integer())) :: integer()
+  def f(l) do
+    l |> hd()
+  end
+end
+
+defmodule Annotations.ShouldFail.BadAnno do
+  use Gradient.TypeAnnotation
+
+  @spec f(list(integer())) :: integer()
+  def f(l) do
+    l |> assert_type(float()) |> hd()
+  end
+end

--- a/test/examples/annotations.ex
+++ b/test/examples/annotations.ex
@@ -5,6 +5,14 @@ defmodule Annotations.ShouldPass do
   def f(l) do
     l |> assert_type(nonempty_list()) |> hd()
   end
+
+  @spec remote_type_anno(String.t() | atom()) :: [String.t()]
+  def remote_type_anno(s) do
+    case s do
+      a when is_atom(a) -> to_string(a)
+      s -> s
+    end |> assert_type(String.t()) |> String.split(" ")
+  end
 end
 
 defmodule Annotations.ShouldFail.NoAnno do

--- a/test/gradient/type_annotation_test.exs
+++ b/test/gradient/type_annotation_test.exs
@@ -8,24 +8,32 @@ defmodule Gradient.TypeAnnotationTest do
 
   test "no annotation leads to check failure" do
     path = "test/examples/_build/Elixir.Annotations.ShouldFail.NoAnno.beam"
-    io_data = capture_io(fn ->
-      assert :error = Gradient.type_check_file(path, @no_color)
-    end)
+
+    io_data =
+      capture_io(fn ->
+        assert :error = Gradient.type_check_file(path, @no_color)
+      end)
+
     assert String.contains?(io_data, "expected to have type nonempty_list")
   end
 
   test "invalid annotation leads to check failure" do
     path = "test/examples/_build/Elixir.Annotations.ShouldFail.BadAnno.beam"
-    io_data = capture_io(fn ->
-      assert :error = Gradient.type_check_file(path, @no_color)
-    end)
+
+    io_data =
+      capture_io(fn ->
+        assert :error = Gradient.type_check_file(path, @no_color)
+      end)
+
     assert String.contains?(io_data, "expected to have type float")
   end
 
   test "valid annotation ensures successful check" do
     path = "test/examples/_build/Elixir.Annotations.ShouldPass.beam"
-    io_data = capture_io(fn ->
-      assert :ok = Gradient.type_check_file(path)
-    end)
+
+    io_data =
+      capture_io(fn ->
+        assert :ok = Gradient.type_check_file(path)
+      end)
   end
 end

--- a/test/gradient/type_annotation_test.exs
+++ b/test/gradient/type_annotation_test.exs
@@ -28,12 +28,11 @@ defmodule Gradient.TypeAnnotationTest do
     assert String.contains?(io_data, "expected to have type float")
   end
 
-  test "valid annotation ensures successful check" do
+  test "valid annotations ensure a successful check" do
     path = "test/examples/_build/Elixir.Annotations.ShouldPass.beam"
 
-    io_data =
-      capture_io(fn ->
-        assert :ok = Gradient.type_check_file(path)
-      end)
+    capture_io(fn ->
+      assert :ok = Gradient.type_check_file(path)
+    end)
   end
 end

--- a/test/gradient/type_annotation_test.exs
+++ b/test/gradient/type_annotation_test.exs
@@ -1,0 +1,31 @@
+defmodule Gradient.TypeAnnotationTest do
+  use ExUnit.Case
+
+  import Gradient.TestHelpers
+  import ExUnit.CaptureIO
+
+  @no_color [ex_colors: [use_colors: false]]
+
+  test "no annotation leads to check failure" do
+    path = "test/examples/_build/Elixir.Annotations.ShouldFail.NoAnno.beam"
+    io_data = capture_io(fn ->
+      assert :error = Gradient.type_check_file(path, @no_color)
+    end)
+    assert String.contains?(io_data, "expected to have type nonempty_list")
+  end
+
+  test "invalid annotation leads to check failure" do
+    path = "test/examples/_build/Elixir.Annotations.ShouldFail.BadAnno.beam"
+    io_data = capture_io(fn ->
+      assert :error = Gradient.type_check_file(path, @no_color)
+    end)
+    assert String.contains?(io_data, "expected to have type float")
+  end
+
+  test "valid annotation ensures successful check" do
+    path = "test/examples/_build/Elixir.Annotations.ShouldPass.beam"
+    io_data = capture_io(fn ->
+      assert :ok = Gradient.type_check_file(path)
+    end)
+  end
+end


### PR DESCRIPTION
This addresses manually adding type annotations as suggested in #98 and in #82.

`Gradient.TypeAnnotation` was too simplistic, therefore it failed properly converting and forwarding the type to Erlang. This shouldn't be the case anymore.

However, this change seems to uncover another issue. It seems that the following ~is~ was possible before the fix:

```elixir
@spec f(list(integer())) :: integer()
def f(list) do
  list |> assert_type(float()) |> hd()
end
```

~That is, the asserted type is not checked against the following function's spec, which leads to incorrect result of the type check.~ This doesn't seem to be the case upstream, see https://github.com/josefs/Gradualizer/blob/6fe5a6767cd2f63b18c7f1293a26d4cd8fc30cdd/test/should_fail/annotated_types_fail.erl for reference.

EDIT: problem solved, the type was not properly passed from Gradient to Gradualizer, but the upstream worked properly all the time.