### PR TITLE
Do not check macro injected code

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.12.3
-erlang 24.3.4
+elixir 1.13.4-otp-24
+erlang 24.1

--- a/lib/gradient.ex
+++ b/lib/gradient.ex
@@ -40,9 +40,12 @@ defmodule Gradient do
          {:elixir, _} <- wrap_language_name(first_ast) do
       asts
       |> Enum.map(fn ast ->
-        ast = put_source_path(ast, opts)
+        ast =
+          ast
+          |> put_source_path(opts)
+          |> maybe_specify_forms(opts)
+
         tokens = maybe_use_tokens(ast, opts)
-        ast = maybe_specify_forms(ast, tokens, opts)
         opts = [{:env, build_env(tokens)} | opts]
 
         case maybe_gradient_check(ast, opts) ++
@@ -115,7 +118,7 @@ defmodule Gradient do
     end
   end
 
-  defp maybe_specify_forms(forms, tokens, opts) do
+  defp maybe_specify_forms(forms, opts) do
     unless opts[:no_specify] do
       forms
       |> put_source_path(opts)

--- a/lib/gradient/tokens.ex
+++ b/lib/gradient/tokens.ex
@@ -60,6 +60,22 @@ defmodule Gradient.Tokens do
     end
   end
 
+  def find_macro_lines([
+        {:identifier, {l, _, _}, :use},
+        {:alias, {l, _, _}, _},
+        {:eol, {l, _, _}} | t
+      ]) do
+    [l | find_macro_lines(t)]
+  end
+
+  def find_macro_lines([_ | t]) do
+    find_macro_lines(t)
+  end
+
+  def find_macro_lines([]) do
+    []
+  end
+
   @doc """
   Drop tokens to the first tuple occurrence. Returns type of the encountered 
   list and the following tokens.

--- a/lib/mix/tasks/gradient.ex
+++ b/lib/mix/tasks/gradient.ex
@@ -12,7 +12,8 @@ defmodule Mix.Tasks.Gradient do
     * `--no-gradualizer-check` - do not perform the Gradualizer checks
     * `--no-specify` - do not specify missing lines in AST what can
       result in less precise error messages
-    * `--source-path` -  provide a path to the .ex file containing code for analyzed .beam
+    * `--source-path` - provide a path to the .ex file containing code for analyzed .beam
+    * `--no-tokens` - do not use tokens to increase the precision of typechecking
 
     * `--no-deps` - do not import dependencies to the Gradualizer
     * `--stop_on_first_error` - stop type checking at the first error
@@ -44,6 +45,7 @@ defmodule Mix.Tasks.Gradient do
     no_specify: :boolean,
     # checker options
     source_path: :string,
+    no_tokens: :boolean,
     no_deps: :boolean,
     stop_on_first_error: :boolean,
     infer: :boolean,

--- a/test/examples/spec_in_macro.ex
+++ b/test/examples/spec_in_macro.ex
@@ -1,0 +1,21 @@
+defmodule NewMod do
+  defmacro __using__(_) do
+    quote do
+      @spec new(attrs :: map()) :: atom()
+      def new(_attrs), do: :ok
+
+      @spec a(attrs :: map()) :: atom()
+      def a(_attrs), do: :ok
+
+      @spec b(attrs :: map()) :: atom()
+      def b(_attrs), do: :ok
+    end
+  end
+end
+
+defmodule SpecInMacro do
+  use NewMod
+
+  @spec c(attrs :: map()) :: atom()
+  def c(_attrs), do: :ok
+end

--- a/test/gradient/elixir_checker_test.exs
+++ b/test/gradient/elixir_checker_test.exs
@@ -9,27 +9,26 @@ defmodule Gradient.ElixirCheckerTest do
   test "checker options" do
     ast = load("Elixir.SpecWrongName.beam")
 
-    assert [] = ElixirChecker.check(ast, ex_check: false)
-    assert [] != ElixirChecker.check(ast, ex_check: true)
+    assert [] = ElixirChecker.check(ast, env([], ex_check: false))
+    assert [] != ElixirChecker.check(ast, env([], ex_check: true))
   end
 
   test "all specs are correct" do
     ast = load("Elixir.CorrectSpec.beam")
 
-    assert [] = ElixirChecker.check(ast, ex_check: true)
+    assert [] = ElixirChecker.check(ast, env())
   end
 
   test "specs over default args are correct" do
     ast = load("Elixir.SpecDefaultArgs.beam")
 
-    assert [] = ElixirChecker.check(ast, ex_check: true)
+    assert [] = ElixirChecker.check(ast, env())
   end
 
   test "spec arity doesn't match the function arity" do
     ast = load("Elixir.SpecWrongArgsArity.beam")
 
-    assert [{_, {:spec_error, :wrong_spec_name, 2, :foo, 3}}] =
-             ElixirChecker.check(ast, ex_check: true)
+    assert [{_, {:spec_error, :wrong_spec_name, 2, :foo, 3}}] = ElixirChecker.check(ast, env())
   end
 
   test "spec name doesn't match the function name" do
@@ -38,7 +37,7 @@ defmodule Gradient.ElixirCheckerTest do
     assert [
              {_, {:spec_error, :wrong_spec_name, 5, :convert, 1}},
              {_, {:spec_error, :wrong_spec_name, 11, :last_two, 1}}
-           ] = ElixirChecker.check(ast, [])
+           ] = ElixirChecker.check(ast, env())
   end
 
   test "mixing specs names is not allowed" do
@@ -47,6 +46,22 @@ defmodule Gradient.ElixirCheckerTest do
     assert [
              {_, {:spec_error, :mixed_specs, 3, :encode, 1}},
              {_, {:spec_error, :wrong_spec_name, 3, :encode, 1}}
-           ] = ElixirChecker.check(ast, [])
+           ] = ElixirChecker.check(ast, env())
+  end
+
+  test "spec defined in a __using__ macro with tokens" do
+    {tokens, ast} = load("Elixir.SpecInMacro.beam", "spec_in_macro.ex")
+
+    assert [] = ElixirChecker.check(ast, env(tokens))
+  end
+
+  test "spec defined in a __using__ macro without tokens" do
+    ast = load("Elixir.SpecInMacro.beam")
+
+    assert [] = ElixirChecker.check(ast, env())
+  end
+
+  defp env(tokens \\ [], opts \\ []) do
+    [{:env, Gradient.build_env(tokens)} | opts]
   end
 end


### PR DESCRIPTION
This PR should fix #99. The spec position of the forms injected into the module by the `use` macro shouldn't be checked because it doesn't have the correct line. 

Ways how we can filter out injected forms:
1. Gather the `macro_lines` (locations that injected forms inherit from the `use` macro) from the token stream and do not check forms with these lines.
2. Drop all the forms that do not have a unique line.

Currently, If the token stream exists, it is used to build `env` that stores info about the analysed module. Then that `env` can be used to detect the forms injected from the `use` macro. If the token stream does not exist, the second method is used.

I know that only the second method should be enough, but I feel that collecting this `env` information can be useful in other places. 