### PR TITLE
Handle not generated one call functions

### DIFF
--- a/lib/gradient/elixir_checker.ex
+++ b/lib/gradient/elixir_checker.ex
@@ -106,6 +106,9 @@ defmodule Gradient.ElixirChecker do
   end
 
   def all_vars_generated?(vars) do
-    Enum.all?(vars, fn {:var, anno, _} -> :erl_anno.generated(anno) end)
+    Enum.all?(vars, fn
+      {:var, anno, _} -> :erl_anno.generated(anno)
+      _ -> false
+    end)
   end
 end


### PR DESCRIPTION
I forgot that users could create functions with one call too, and we can have pattern matching there. This fixes the function clause errors