### PR TITLE
Set MIX_ENV=test in CI to use compile step

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      MIX_ENV: test
     name: Erlang ${{matrix.otp}} / Elixir ${{matrix.elixir}}
     strategy:
       matrix:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,6 +26,6 @@ jobs:
       - name: "Get and compile deps"
         run: "mix deps.get && mix deps.compile"
       - name: "Build"
-        run: "mix compile"
+        run: "mix compile --warnings-as-errors"
       - name: "Test"
         run: "mix test"


### PR DESCRIPTION
This PR sets `MIX_ENV=test` in CI so the step that does `mix compile` is not duplicated by `mix test`. Now both are compiling, as the former is compiling for `dev` env, and `mix test` is compiling for `test` env.

Also adding the option `--warnings-as-errors` to `mix compile`, so we ensure overtime no compilation warnings are introduced to gradient users when compiling the dep 👍