### PR TITLE
Fix some test warnings

### DIFF
--- a/test/gradient/type_annotation_test.exs
+++ b/test/gradient/type_annotation_test.exs
@@ -1,7 +1,6 @@
 defmodule Gradient.TypeAnnotationTest do
   use ExUnit.Case
 
-  import Gradient.TestHelpers
   import ExUnit.CaptureIO
 
   @no_color [ex_colors: [use_colors: false]]

--- a/test/gradient_test.exs
+++ b/test/gradient_test.exs
@@ -2,7 +2,6 @@ defmodule GradientTest do
   use ExUnit.Case
   doctest Gradient
 
-  import Gradient.TestHelpers
   import ExUnit.CaptureIO
 
   test "typecheck erlang beam" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,8 +2,6 @@ defmodule ExamplesCompiler do
   @build_path "test/examples/_build/"
   @erl_build_path "test/examples/erlang/_build/"
 
-  @version_step 0.01
-
   @version (case System.version() do
               v when v >= "1.13" -> 1.13
               v when v >= "1.12" -> 1.12


### PR DESCRIPTION
This PR fixes some warnings in test code.

Unfortunately, that's not enough to turn on the flag `--warnings-as-errors` in `mix test`. There are a few AST's in `Gradient.ElixirExprTest` that have unused vars or literals, not sure if you'd want to change those.

```elixir
❯ mix test
Excluding tags: [:ex_lt_1_11, :ex_lt_1_12, :ex_lt_1_13, :ex_gt_1_13]

warning: code block contains unused literal 11 (remove the literal or assign it to _ to avoid warnings)
  nofile:34

warning: variable "v" is unused (if the variable is not meant to be used, prefix it with an underscore)
  nofile:204

warning: code block contains unused literal 11 (remove the literal or assign it to _ to avoid warnings)
  nofile:34

warning: code block contains unused literal 12 (remove the literal or assign it to _ to avoid warnings)
  nofile:34

***....................................**........................................................................................................................................................................

Finished in 1.0 seconds (0.00s async, 1.0s sync)
211 tests, 0 failures, 2 excluded, 5 skipped
```