### PR TITLE
Add guard to fix crash in AstSpecifier

### DIFF
--- a/lib/gradient/ast_specifier.ex
+++ b/lib/gradient/ast_specifier.ex
@@ -657,7 +657,7 @@ defmodule Gradient.AstSpecifier do
   defp match_token_to_form(
          {:bin_string, {l1, _, _}, [v1]},
          {:bin, l2, [{:bin_element, _, {:string, _, v2}, :default, :default}]}
-       ) do
+       ) when is_binary(v1) do
     # string
     l2 <= l1 && :binary.bin_to_list(v1) == v2
   end


### PR DESCRIPTION
`:binary.bin_to_list/1` expects a `binary()`, and without this guard, this function crashed when running gradient in a private repo, after printing a few other errors:


```elixir
** (ArgumentError) errors were found at the given arguments:

  * 1st argument: not a binary

    (stdlib 3.17.2) binary.erl:497: :binary.bin_to_list({{149, 26, nil}, {149, 33, nil}, [{:identifier, {149, 28, nil}, :index}]})
    (gradient 0.1.0) lib/gradient/ast_specifier.ex:662: Gradient.AstSpecifier.match_token_to_form/2
    (gradient 0.1.0) lib/gradient/ast_specifier.ex:581: anonymous fn/2 in Gradient.AstSpecifier.specify_line/3
    (gradient 0.1.0) lib/gradient/tokens.ex:99: Gradient.Tokens.drop_tokens_while/3
    (gradient 0.1.0) lib/gradient/ast_specifier.ex:581: Gradient.AstSpecifier.specify_line/3
    (gradient 0.1.0) lib/gradient/ast_specifier.ex:531: Gradient.AstSpecifier.map_element_mapper/3
    (gradient 0.1.0) lib/gradient/ast_specifier.ex:81: Gradient.AstSpecifier.context_mapper_fold/4
    (gradient 0.1.0) lib/gradient/ast_specifier.ex:82: Gradient.AstSpecifier.context_mapper_fold/4
```

With this fix it doesn't raise the error anymore 👍