### PR TITLE
Fix get_line_from_token/1 spec

### DIFF
--- a/lib/gradient/tokens.ex
+++ b/lib/gradient/tokens.ex
@@ -120,7 +120,7 @@ defmodule Gradient.Tokens do
   @doc """
   Get line from token.
   """
-  @spec get_line_from_token(T.token()) :: integer()
+  @spec get_line_from_token(T.token()) :: :erl_anno.line()
   def get_line_from_token(token), do: elem(elem(token, 1), 0)
 
   def get_line_from_form(form) do


### PR DESCRIPTION
```elixir
lib/gradient/ast_specifier.ex:745: The variable is expected to have type non_neg_integer() but it has type integer()
743   def update_line_from_tokens([token | _], anno, opts) do
744     line = get_line_from_token(token)
745     {:erl_anno.set_line(line, anno), Keyword.put(opts, :line, line)}
746   end
747
```