### PR TITLE
Fix erl_parse:mapfold_anno type error

### DIFF
--- a/test/support/ast_data.ex
+++ b/test/support/ast_data.ex
@@ -65,8 +65,8 @@ defmodule Gradient.AstData do
         :ok
         |> elem(0)
       end, __ENV__.line},
-     {:call, 56, {:remote, 56, {:atom, 56, :erlang}, {:atom, 56, :element}},
-      [{:integer, 56, 1}, {:atom, 55, :ok}]}}
+     {:call, 66, {:remote, 66, {:atom, 66, :erlang}, {:atom, 66, :element}},
+      [{:integer, 66, 1}, {:atom, 65, :ok}]}}
   end
 
   defp complex_list_pipe do
@@ -115,22 +115,29 @@ defmodule Gradient.AstData do
         }
         |> Tuple.to_list()
       end, __ENV__.line},
-     {:call, 119, {:remote, 119, {:atom, 119, :erlang}, {:atom, 119, :tuple_to_list}},
-      [
-        {:tuple, 115,
-         [
-           {:tuple, 116,
-            [
-              {:integer, 116, 1},
-              {:map, 116, [{:map_field_assoc, 116, {:atom, 116, :a}, {:integer, 116, 1}}]}
-            ]},
-           {:tuple, 117,
-            [
-              {:integer, 117, 2},
-              {:map, 117, [{:map_field_assoc, 117, {:atom, 117, :a}, {:integer, 117, 2}}]}
-            ]}
-         ]}
-      ]}}
+     {
+       :call,
+       116,
+       {:remote, 116, {:atom, 116, :erlang}, {:atom, 116, :tuple_to_list}},
+       [
+         {
+           :tuple,
+           112,
+           [
+             {:tuple, 113,
+              [
+                {:integer, 113, 1},
+                {:map, 113, [{:map_field_assoc, 113, {:atom, 113, :a}, {:integer, 113, 1}}]}
+              ]},
+             {:tuple, 114,
+              [
+                {:integer, 114, 2},
+                {:map, 114, [{:map_field_assoc, 114, {:atom, 114, :a}, {:integer, 114, 2}}]}
+              ]}
+           ]
+         }
+       ]
+     }}
   end
 
   @spec ast_data() :: [

--- a/test/support/ast_data.ex
+++ b/test/support/ast_data.ex
@@ -154,19 +154,18 @@ defmodule Gradient.AstData do
     {expression, _} =
       :erl_parse.mapfold_anno(
         fn anno, acc ->
-          line =
-            case :erl_anno.line(anno) - acc do
-              line when is_integer(line) and line >= 0 ->
-                line
+          line = :erl_anno.line(anno) - acc
+          column = :erl_anno.column(anno)
+
+          location =
+            case {line, column} do
+              {l, c} when is_integer(l) and l >= 0 and is_integer(c) and c > 0 ->
+                {l, c}
+
+              other ->
+                raise "Could not normalize expression with anno: #{inspect(anno)} and acc #{inspect(acc)}, got: #{inspect(other)}, expression: #{inspect(expression)}"
             end
 
-          column =
-            case :erl_anno.column(anno) do
-              column when is_integer(column) and column > 0 ->
-                column
-            end
-
-          location = {line, column}
           {location, acc}
         end,
         :erl_anno.line(elem(expression, 1)),

--- a/test/support/ast_data.ex
+++ b/test/support/ast_data.ex
@@ -154,7 +154,20 @@ defmodule Gradient.AstData do
     {expression, _} =
       :erl_parse.mapfold_anno(
         fn anno, acc ->
-          {{:erl_anno.line(anno) - acc, :erl_anno.column(anno)}, acc}
+          line =
+            case :erl_anno.line(anno) - acc do
+              line when is_integer(line) and line >= 0 ->
+                line
+            end
+
+          column =
+            case :erl_anno.column(anno) do
+              column when is_integer(column) and column > 0 ->
+                column
+            end
+
+          location = {line, column}
+          {location, acc}
         end,
         :erl_anno.line(elem(expression, 1)),
         expression

--- a/test/support/ast_data.ex
+++ b/test/support/ast_data.ex
@@ -159,11 +159,13 @@ defmodule Gradient.AstData do
 
           location =
             case {line, column} do
-              {l, c} when is_integer(l) and l >= 0 and is_integer(c) and c > 0 ->
+              {l, c}
+              when is_integer(l) and l >= 0 and
+                     is_integer(c) and c > 0 ->
                 {l, c}
 
-              other ->
-                raise "Could not normalize expression with anno: #{inspect(anno)} and acc #{inspect(acc)}, got: #{inspect(other)}, expression: #{inspect(expression)}"
+              _ ->
+                anno
             end
 
           {location, acc}


### PR DESCRIPTION
```elixir
test/support/ast_data.ex:156: The tuple is expected to have type anno() but it has type {integer(), column() | :undefined}
154     {expression, _} =
155       :erl_parse.mapfold_anno(
156         fn anno, acc ->
157           {{:erl_anno.line(anno) - acc, :erl_anno.column(anno)}, acc}
158         end,
```
