### PR TITLE
Handle corner cases on erlang_ast/1 and get_forms/1

### DIFF
--- a/lib/gradient/debug.ex
+++ b/lib/gradient/debug.ex
@@ -48,8 +48,18 @@ defmodule Gradient.Debug do
   """
   @spec erlang_ast(module()) :: {:ok, [erlang_form()]}
   def erlang_ast(mod) do
-    {:ok, _forms} =
-      get_beam_path_as_charlist(mod) |> Gradient.ElixirFileUtils.get_forms_from_beam()
+    result =
+      mod
+      |> get_beam_path_as_charlist()
+      |> Gradient.ElixirFileUtils.get_forms_from_beam()
+
+    case result do
+      {:ok, _forms} = ok ->
+        ok
+
+      error ->
+        raise "Could not get erlang forms for module #{inspect(mod)}, error:\n #{inspect(error)}"
+    end
   end
 
   @doc ~S"""

--- a/lib/gradient/elixir_file_utils.ex
+++ b/lib/gradient/elixir_file_utils.ex
@@ -62,10 +62,18 @@ defmodule Gradient.ElixirFileUtils do
         get_forms_from_ex(path)
 
       _ ->
-        [path]
-        |> Module.concat()
-        |> :code.which()
-        |> get_forms_from_beam()
+        which =
+          [path]
+          |> Module.concat()
+          |> :code.which()
+
+        case which do
+          filename when is_list(filename) ->
+            get_forms_from_beam(filename)
+
+          other ->
+            raise "Could not get forms for path #{inspect(path)}, got #{inspect(other)}"
+        end
     end
   end
 


### PR DESCRIPTION
```elixir
lib/gradient/debug.ex:52: The function call is expected to have type {:ok, list(erlang_form())} but it has type {:ok, abstract_forms()} | parsed_file_error()
50   def erlang_ast(mod) do
51     {:ok, _forms} =
52       get_beam_path_as_charlist(mod) |> Gradient.ElixirFileUtils.get_forms_from_beam()
53   end
54

lib/gradient/elixir_file_utils.ex:67: The function call is expected to have type path() but it has type :cover_compiled | :non_existing | :preloaded | list(char())
65         [path]
66         |> Module.concat()
67         |> :code.which()
68         |> get_forms_from_beam()
69     end
```