### PR TITLE
[FEAT] Add standalone Gradient escript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ test/examples/erlang/_build/
 
 # MacOS DS_Store
 .DS_Store
+
+.elixir_ls

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 elixir 1.12.3
-erlang 24.1
+erlang 24.3.4

--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -42,7 +42,7 @@ defmodule Gradient.CLI do
     no_gradualizer_check: :boolean,
     no_specify: :boolean,
     # checker options
-    code_path: :string,
+    source_path: :string,
     no_deps: :boolean,
     stop_on_first_error: :boolean,
     infer: :boolean,
@@ -94,7 +94,14 @@ defmodule Gradient.CLI do
         do: stream,
         else: Enum.to_list(stream)
 
-    case Enum.count(res, &(&1 != :ok)) do
+    res
+    |> Enum.reduce(0, fn
+      :ok, acc -> acc
+      :error, acc -> acc + 1
+      {:error, errors}, acc -> errors |> Enum.count() |> Kernel.+(acc)
+      _, acc -> acc + 1
+    end)
+    |> case do
       0 ->
         IO.puts([
           IO.ANSI.bright(),
@@ -154,8 +161,6 @@ defmodule Gradient.CLI do
   defp prepare_option({:no_fancy, _}, opts), do: [{:fancy, false} | opts]
 
   defp prepare_option({:stop_on_first_error, _}, opts), do: [{:crash_on_error, true} | opts]
-
-  defp prepare_option({:source_path, path}, opts), do: [{:code_path, path} | opts]
 
   defp prepare_option({k, v}, opts), do: [{k, v} | opts]
 

--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -66,6 +66,10 @@ defmodule Gradient.CLI do
     options = Enum.reduce(options, [], &prepare_option/2)
 
     if module_flag_absent_or_provided_with_file_path?(options, user_paths) do
+      # Gradualizer has to be stopped, otherwise adding the extra code paths won't take effect.
+      # We don't want to worry the user with the stop message, though.
+      Logger.configure(level: :warning)
+      Application.stop(:gradualizer)
       maybe_path_add(options)
       # Start Gradualizer application
       Application.ensure_all_started(:gradualizer)

--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -11,7 +11,7 @@ defmodule Gradient.CLI do
     * `--no-gradualizer-check` - do not perform the Gradualizer checks
     * `--no-specify` - do not specify missing lines in AST what can
       result in less precise error messages
-    * `--code-path` -  provide a path to the .ex file containing code for analyzed .beam
+    * `--source-path` -  provide a path to the .ex file containing code for analyzed .beam
 
     * `--no-deps` - do not import dependencies to the Gradualizer
     * `--stop_on_first_error` - stop type checking at the first error
@@ -29,8 +29,8 @@ defmodule Gradient.CLI do
     * `--underscore-color ansicode` - set color for the underscored invalid code part
       in the fancy messages
 
-    # --path_add - add path to the `/ebin` directory for dependencies
-    # --module - add name of the module to check in specific file
+    # --path-add - append a list of comma-delimited paths to the Erlang code path
+    # --module - add name of the specific module to check in a source file
 
   Warning! Flags passed to this task are passed on to Gradualizer.
   """
@@ -70,7 +70,7 @@ defmodule Gradient.CLI do
       # Start Gradualizer application
       Application.ensure_all_started(:gradualizer)
 
-      # # Get paths to files
+      # Get paths to files
       files = get_paths(user_paths, options)
 
       IO.puts("Typechecking files...")
@@ -84,7 +84,7 @@ defmodule Gradient.CLI do
 
       :ok
     else
-      IO.puts("Flag --module has to be used with path to single *.ex file.")
+      IO.puts("Use --module when pointing at a single *.ex file.")
     end
   end
 
@@ -130,8 +130,6 @@ defmodule Gradient.CLI do
       end)
       |> :code.add_paths()
     end
-
-    # end
   end
 
   defp prepare_color_option(opts, pair) do
@@ -156,6 +154,8 @@ defmodule Gradient.CLI do
   defp prepare_option({:no_fancy, _}, opts), do: [{:fancy, false} | opts]
 
   defp prepare_option({:stop_on_first_error, _}, opts), do: [{:crash_on_error, true} | opts]
+
+  defp prepare_option({:source_path, path}, opts), do: [{:code_path, path} | opts]
 
   defp prepare_option({k, v}, opts), do: [{k, v} | opts]
 

--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -80,9 +80,7 @@ defmodule Gradient.CLI do
       IO.puts("Typechecking files...")
 
       files
-      |> Stream.map(fn {app_path, paths} ->
-        Stream.map(paths, &Gradient.type_check_file(&1, [{:app_path, app_path} | options]))
-      end)
+      |> Stream.map(&Gradient.type_check_file(&1, options))
       |> Stream.concat()
       |> execute(options)
 
@@ -177,15 +175,13 @@ defmodule Gradient.CLI do
 
   defp prepare_option({k, v}, opts), do: [{k, v} | opts]
 
-  defp get_paths([], _options) do
-    %{nil => get_paths_from_dir([File.cwd!()])}
-  end
+  defp get_paths([], _options), do: get_paths_from_dir([File.cwd!()])
 
-  defp get_paths(paths, _options), do: %{nil => get_paths_from_dir(paths)}
+  defp get_paths(paths, _options), do: get_paths_from_dir(paths)
 
   defp get_paths_from_dir(paths) do
     paths
-    |> Enum.map(fn p ->
+    |> Enum.flat_map(fn p ->
       if File.dir?(p) do
         expanded_path = Path.expand(p)
         Path.wildcard(Path.join([expanded_path, "/**/*.ex"]))
@@ -193,7 +189,6 @@ defmodule Gradient.CLI do
         [p]
       end
     end)
-    |> Enum.concat()
   end
 
   defp module_flag_absent_or_provided_with_file_path?(options, user_paths) do

--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -29,6 +29,9 @@ defmodule Gradient.CLI do
     * `--underscore-color ansicode` - set color for the underscored invalid code part
       in the fancy messages
 
+    # --path_add - add path to the `/ebin` directory for dependencies
+    # --module - add name of the module to check in specific file
+
   Warning! Flags passed to this task are passed on to Gradualizer.
   """
 
@@ -86,7 +89,10 @@ defmodule Gradient.CLI do
   end
 
   defp execute(stream, opts) do
-    res = if opts[:crash_on_error], do: stream, else: Enum.to_list(stream)
+    res =
+      if opts[:crash_on_error],
+        do: stream,
+        else: Enum.to_list(stream)
 
     case Enum.count(res, &(&1 != :ok)) do
       0 ->
@@ -163,8 +169,8 @@ defmodule Gradient.CLI do
     paths
     |> Enum.map(fn p ->
       if File.dir?(p) do
-        expanded_path = Path.expand(p) |> IO.inspect(label: :EXPANDE_PATH)
-        Path.wildcard(Path.join([expanded_path, "/**/*.ex"])) |> IO.inspect(label: :WILD_PATH)
+        expanded_path = Path.expand(p)
+        Path.wildcard(Path.join([expanded_path, "/**/*.ex"]))
       else
         [p]
       end
@@ -173,24 +179,17 @@ defmodule Gradient.CLI do
   end
 
   defp module_flag_absent_or_provided_with_file_path?(options, user_paths) do
-    module_flag = Keyword.get(options, :module, nil) |> IO.inspect(label: :KEYWORD_GET)
+    module_flag = Keyword.get(options, :module, nil)
 
     cond do
-      is_nil(module_flag) && Enum.count(user_paths) == 1 &&
-          String.ends_with?(List.first(user_paths), ".ex") ->
-        IO.inspect("MODULE_absent, one path and ends with .ex")
-        false
-
       is_binary(module_flag) && Enum.count(user_paths) == 1 &&
           String.ends_with?(List.first(user_paths), ".ex") ->
-        IO.inspect("MODULE_PRESENT, one path and ends with .ex")
         true
 
       is_nil(module_flag) ->
         true
 
       true ->
-        IO.inspect("DEFAULT false")
         false
     end
   end

--- a/lib/gradient.ex
+++ b/lib/gradient.ex
@@ -33,10 +33,10 @@ defmodule Gradient do
     opts = Keyword.put(opts, :return_errors, true)
     module = Keyword.get(opts, :module, "all_modules")
 
-    with {:ok, forms} <- ElixirFileUtils.get_forms(path, module),
-         {:ok, first_forms} <- get_first_forms(forms),
-         {:elixir, _} <- wrap_language_name(first_forms) do
-      forms
+    with {:ok, asts} <- ElixirFileUtils.get_forms(path, module),
+         {:ok, first_ast} <- get_first_forms(asts),
+         {:elixir, _} <- wrap_language_name(first_ast) do
+      asts
       |> Enum.flat_map(fn module_forms ->
         single_module_forms = maybe_specify_forms(module_forms, opts)
 
@@ -46,12 +46,12 @@ defmodule Gradient do
             [:ok]
 
           errors ->
-            opts = Keyword.put(opts, :forms, forms)
+            opts = Keyword.put(opts, :forms, single_module_forms)
             ElixirFmt.print_errors(errors, opts)
-            [:error]
+
+            List.duplicate(:error, Enum.count(errors))
         end
       end)
-      |> IO.inspect(label: :FLAT_MAP_RESULT)
     else
       {:erlang, forms} ->
         opts = Keyword.put(opts, :return_errors, false)

--- a/lib/gradient/elixir_file_utils.ex
+++ b/lib/gradient/elixir_file_utils.ex
@@ -48,6 +48,8 @@ defmodule Gradient.ElixirFileUtils do
         path
         |> Code.compile_file()
         |> Enum.reduce([], fn {required_module_name, binary}, acc ->
+          ensure_module_loaded_into_gradualizer(binary)
+
           if module != "all_modules" do
             string_module_name = Atom.to_string(required_module_name)
 
@@ -115,5 +117,14 @@ defmodule Gradient.ElixirFileUtils do
         IO.puts("Cannot load tokens: #{inspect(error)}")
         []
     end
+  end
+
+  defp ensure_module_loaded_into_gradualizer(binary) do
+    {path, _} = System.cmd("mktemp", [])
+    sanitized_path = path |> String.trim() |> Kernel.<>(".beam")
+
+    :file.write_file(to_charlist(sanitized_path), binary)
+
+    :gradualizer_db.import_beam_files([to_charlist(sanitized_path)])
   end
 end

--- a/lib/gradient/elixir_file_utils.ex
+++ b/lib/gradient/elixir_file_utils.ex
@@ -21,8 +21,6 @@ defmodule Gradient.ElixirFileUtils do
   @spec get_forms_from_beam(path()) ::
           {:ok, abstract_forms()} | parsed_file_error()
   def get_forms_from_beam(path) do
-    # IO.inspect(path, label: :PATH_IN_GET_FORMS_FROM_BEAM)
-
     case :beam_lib.chunks(path, [:abstract_code]) do
       {:ok, {_module, [{:abstract_code, {:raw_abstract_v1, forms}}]}} ->
         {:ok, forms}
@@ -46,8 +44,6 @@ defmodule Gradient.ElixirFileUtils do
   def get_forms_from_ex(path, module \\ "all_modules") do
     # For compiling many files concurrently, see Kernel.ParallelCompiler.compile/2.
     if File.exists?(path) do
-      # IO.inspect(path, label: :FILEEXISTS)
-
       forms =
         path
         |> Code.require_file()
@@ -66,16 +62,6 @@ defmodule Gradient.ElixirFileUtils do
             [forms | acc]
           end
         end)
-
-      # |> IO.inspect(label: :REQUIRE_FILE)
-      # change to reduce
-      # |> maybe_filter_required_modules(module)
-      # [{module_name, binary}, {}]
-      # |> Enum.map(fn {_module, bin} ->
-      # {:ok, forms} = get_forms_from_beam(bin)
-      # IO.inspect(forms, label: :FORMS_FROM_BEAM)
-      # forms
-      # end)
 
       {:ok, forms}
     else

--- a/lib/gradient/elixir_file_utils.ex
+++ b/lib/gradient/elixir_file_utils.ex
@@ -123,8 +123,8 @@ defmodule Gradient.ElixirFileUtils do
     {path, _} = System.cmd("mktemp", [])
     sanitized_path = path |> String.trim() |> Kernel.<>(".beam")
 
-    :file.write_file(to_charlist(sanitized_path), binary)
+    :ok = :file.write_file(to_charlist(sanitized_path), binary)
 
-    :gradualizer_db.import_beam_files([to_charlist(sanitized_path)])
+    :ok = :gradualizer_db.import_beam_files([to_charlist(sanitized_path)])
   end
 end

--- a/lib/gradient/elixir_file_utils.ex
+++ b/lib/gradient/elixir_file_utils.ex
@@ -46,7 +46,7 @@ defmodule Gradient.ElixirFileUtils do
     if File.exists?(path) do
       forms =
         path
-        |> Code.require_file()
+        |> Code.compile_file()
         |> Enum.reduce([], fn {required_module_name, binary}, acc ->
           if module != "all_modules" do
             string_module_name = Atom.to_string(required_module_name)

--- a/lib/mix/tasks/gradient.ex
+++ b/lib/mix/tasks/gradient.ex
@@ -63,6 +63,7 @@ defmodule Mix.Tasks.Gradient do
     {options, user_paths, _invalid} = OptionParser.parse(args, strict: @options)
 
     options = Enum.reduce(options, [], &prepare_option/2)
+
     # Load dependencies
     maybe_load_deps(options)
     # Start Gradualizer application
@@ -85,7 +86,10 @@ defmodule Mix.Tasks.Gradient do
   end
 
   defp execute(stream, opts) do
-    res = if opts[:crash_on_error], do: stream, else: Enum.to_list(stream)
+    res =
+      if opts[:crash_on_error],
+        do: stream,
+        else: Enum.to_list(stream) |> List.flatten()
 
     case Enum.count(res, &(&1 != :ok)) do
       0 ->

--- a/lib/mix/tasks/gradient.ex
+++ b/lib/mix/tasks/gradient.ex
@@ -12,7 +12,7 @@ defmodule Mix.Tasks.Gradient do
     * `--no-gradualizer-check` - do not perform the Gradualizer checks
     * `--no-specify` - do not specify missing lines in AST what can
       result in less precise error messages
-    * `--code-path` -  provide a path to the .ex file containing code for analyzed .beam
+    * `--source-path` -  provide a path to the .ex file containing code for analyzed .beam
 
     * `--no-deps` - do not import dependencies to the Gradualizer
     * `--stop_on_first_error` - stop type checking at the first error
@@ -43,7 +43,7 @@ defmodule Mix.Tasks.Gradient do
     no_gradualizer_check: :boolean,
     no_specify: :boolean,
     # checker options
-    code_path: :string,
+    source_path: :string,
     no_deps: :boolean,
     stop_on_first_error: :boolean,
     infer: :boolean,
@@ -91,7 +91,14 @@ defmodule Mix.Tasks.Gradient do
         do: stream,
         else: Enum.to_list(stream) |> List.flatten()
 
-    case Enum.count(res, &(&1 != :ok)) do
+    res
+    |> Enum.reduce(0, fn
+      :ok, acc -> acc
+      :error, acc -> acc + 1
+      {:error, errors}, acc -> errors |> Enum.count() |> Kernel.+(acc)
+      _, acc -> acc + 1
+    end)
+    |> case do
       0 ->
         IO.puts([
           IO.ANSI.bright(),

--- a/lib/mix/tasks/gradient.ex
+++ b/lib/mix/tasks/gradient.ex
@@ -86,17 +86,26 @@ defmodule Mix.Tasks.Gradient do
   end
 
   defp execute(stream, opts) do
-    res =
-      if opts[:crash_on_error],
-        do: stream,
-        else: Enum.to_list(stream) |> List.flatten()
+    crash_on_error? = Keyword.get(opts, :crash_on_error, false)
 
-    res
-    |> Enum.reduce(0, fn
-      :ok, acc -> acc
-      :error, acc -> acc + 1
-      {:error, errors}, acc -> errors |> Enum.count() |> Kernel.+(acc)
-      _, acc -> acc + 1
+    stream
+    |> Enum.to_list()
+    |> List.flatten()
+    |> Enum.reduce_while(0, fn
+      stream_result, acc ->
+        if not crash_on_error? do
+          stream_result
+          |> case do
+            :ok ->
+              {:cont, acc}
+
+            {:error, errors} ->
+              total_errors = errors |> Enum.count() |> Kernel.+(acc)
+              {:cont, total_errors}
+          end
+        else
+          {:halt, 1}
+        end
     end)
     |> case do
       0 ->

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,8 @@ defmodule Gradient.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       aliases: aliases(),
-      dialyzer: [plt_add_apps: [:mix]]
+      dialyzer: [plt_add_apps: [:mix]],
+      escript: escript()
     ]
   end
 
@@ -37,5 +38,9 @@ defmodule Gradient.MixProject do
 
   def aliases do
     []
+  end
+
+  def escript() do
+    [main_module: Gradient.CLI]
   end
 end

--- a/test/examples/dependent_modules.ex
+++ b/test/examples/dependent_modules.ex
@@ -1,0 +1,8 @@
+defmodule TypeDef do
+  @type t() :: integer()
+end
+
+defmodule FunDef do
+  @spec f() :: TypeDef.t()
+  def f(), do: 1
+end

--- a/test/gradient/type_annotation_test.exs
+++ b/test/gradient/type_annotation_test.exs
@@ -10,7 +10,7 @@ defmodule Gradient.TypeAnnotationTest do
 
     io_data =
       capture_io(fn ->
-        assert [:error] = Gradient.type_check_file(path, @no_color)
+        assert [{:error, _}] = Gradient.type_check_file(path, @no_color)
       end)
 
     assert String.contains?(io_data, "expected to have type nonempty_list")
@@ -21,7 +21,7 @@ defmodule Gradient.TypeAnnotationTest do
 
     io_data =
       capture_io(fn ->
-        assert [:error] = Gradient.type_check_file(path, @no_color)
+        assert [{:error, _}] = Gradient.type_check_file(path, @no_color)
       end)
 
     assert String.contains?(io_data, "expected to have type float")

--- a/test/gradient/type_annotation_test.exs
+++ b/test/gradient/type_annotation_test.exs
@@ -10,7 +10,7 @@ defmodule Gradient.TypeAnnotationTest do
 
     io_data =
       capture_io(fn ->
-        assert :error = Gradient.type_check_file(path, @no_color)
+        assert [:error] = Gradient.type_check_file(path, @no_color)
       end)
 
     assert String.contains?(io_data, "expected to have type nonempty_list")
@@ -21,7 +21,7 @@ defmodule Gradient.TypeAnnotationTest do
 
     io_data =
       capture_io(fn ->
-        assert :error = Gradient.type_check_file(path, @no_color)
+        assert [:error] = Gradient.type_check_file(path, @no_color)
       end)
 
     assert String.contains?(io_data, "expected to have type float")
@@ -31,7 +31,7 @@ defmodule Gradient.TypeAnnotationTest do
     path = "test/examples/_build/Elixir.Annotations.ShouldPass.beam"
 
     capture_io(fn ->
-      assert :ok = Gradient.type_check_file(path)
+      assert [:ok] = Gradient.type_check_file(path)
     end)
   end
 end

--- a/test/gradient_test.exs
+++ b/test/gradient_test.exs
@@ -23,8 +23,7 @@ defmodule GradientTest do
 
     io_data =
       capture_io(fn ->
-        errors = Gradient.type_check_file(path)
-        assert Enum.count(errors) == 23
+        assert [{:error, _}] = Gradient.type_check_file(path)
       end)
 
     assert String.contains?(io_data, ex_path)

--- a/test/gradient_test.exs
+++ b/test/gradient_test.exs
@@ -20,11 +20,17 @@ defmodule GradientTest do
     # typecheck file with errors
     path = "test/examples/_build/Elixir.WrongRet.beam"
     ex_path = "test/examples/type/wrong_ret.ex"
-    io_data = capture_io(fn -> assert :error = Gradient.type_check_file(path) end)
+
+    io_data =
+      capture_io(fn ->
+        errors = Gradient.type_check_file(path)
+        assert Enum.count(errors) == 23
+      end)
+
     assert String.contains?(io_data, ex_path)
     # typecheck correct file
     capture_io(fn ->
-      assert :ok = Gradient.type_check_file("test/examples/_build/Elixir.Basic.beam")
+      assert [:ok] = Gradient.type_check_file("test/examples/_build/Elixir.Basic.beam")
     end)
   end
 end

--- a/test/gradient_test.exs
+++ b/test/gradient_test.exs
@@ -8,7 +8,7 @@ defmodule GradientTest do
     # typecheck file with errors
     path = "test/examples/erlang/_build/test_err.beam"
     erl_path = "test/examples/erlang/test_err.erl"
-    io_data = capture_io(fn -> assert :error = Gradient.type_check_file(path) end)
+    io_data = capture_io(fn -> assert {:error, _} = Gradient.type_check_file(path) end)
     assert String.contains?(io_data, erl_path)
     # typecheck correct file
     capture_io(fn ->

--- a/test/mix/tasks/gradient_test.exs
+++ b/test/mix/tasks/gradient_test.exs
@@ -197,10 +197,10 @@ defmodule Mix.Tasks.GradientTest do
     assert_receive {:system_halt, 1}
   end
 
-  test "--code-path option" do
+  test "--source-path option" do
     ex_file = "wrong_ret.ex"
 
-    output = run_task(test_opts(["--code-path", ex_file, "--", @s_wrong_ret_beam]))
+    output = run_task(test_opts(["--source-path", ex_file, "--", @s_wrong_ret_beam]))
 
     assert not String.contains?(output, @s_wrong_ret_ex)
     assert String.contains?(output, ex_file)

--- a/test/mix/tasks/gradient_test.exs
+++ b/test/mix/tasks/gradient_test.exs
@@ -215,6 +215,10 @@ defmodule Mix.Tasks.GradientTest do
     assert_receive {:system_halt, 1}
   end
 
+  test "dependent modules are loaded" do
+    assert run_task([@examples_path <> "/dependent_modules.ex"]) =~ "No errors found!"
+  end
+
   def run_task(args), do: capture_io(fn -> Mix.Tasks.Gradient.run(args) end)
 
   def test_opts(opts), do: ["--no-comile", "--no-deps"] ++ opts

--- a/test/mix/tasks/gradient_test.exs
+++ b/test/mix/tasks/gradient_test.exs
@@ -208,10 +208,10 @@ defmodule Mix.Tasks.GradientTest do
   end
 
   test "counts errors" do
-    assert run_task([@s_wrong_ret_beam]) =~ "Total errors: 1"
+    assert run_task([@s_wrong_ret_beam]) =~ "Total errors: 2"
     assert_receive {:system_halt, 1}
 
-    assert run_task([@s_wrong_ret_beam, @s_wrong_ret_ex]) =~ "Total errors: 2"
+    assert run_task([@s_wrong_ret_beam, @s_wrong_ret_ex]) =~ "Total errors: 4"
     assert_receive {:system_halt, 1}
   end
 


### PR DESCRIPTION
TODO:
- ~~simplify flow in `lib/gradient.ex` by using Enum.flat_map~~ DONE
- ~~concatenate multiple errors from streams (also connected with Enum.flat_map)~~ DONE
- ~~verify all examples are working correctly on escript and mix task~~
- ~~add documentation for new flags~~ DONE
-  ~~fix tests~~ DONE
- ~~clean up code from comments, inspets ect~~ DONE
- ~~verify that mix task and gradient escript works in the same way (e.g. reports the same errors)~~

FOUND PROBLEMS:
- currently when building `escript` by default there is no elixir beam files provided so gradient/gradualizer does not has access to elixir libraries (e.g. there will be error in `defstruct` macro because under the hood it calls Enum.reduce/2 which is not available by default compared to mix task)
- When `gradient` escript is checking file `./examples/simple_app/lib/simple_app.ex` 2 errors are found but only one is reported, that is not the case e.g for file `./examples/simple_app/simple_app/struct_example.ex`