### PR TITLE
Update .tool-versions elixir/erlang

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.13.4-otp-24
-erlang 24.1
+elixir 1.14.0-otp-25
+erlang 25.1.1


### PR DESCRIPTION
Update Elixir to 1.14.0
Update Erlang to 25.1.1 - solves issues when installing Erlang on Apple Silicon (M1 and up)