### PR TITLE
escript: detect Elixir libs when Elixir is managed by asdf

### DIFF
--- a/.github/workflows/build-and-test-asdf.yml
+++ b/.github/workflows/build-and-test-asdf.yml
@@ -23,7 +23,7 @@ jobs:
           otp-version: ${{matrix.otp}}
       - uses: asdf-vm/actions/install@v1
         with:
-          command: asdf install elixir 1.13.4-otp-25
+          tool_versions: elixir 1.13.4-otp-25
       - name: "Get and compile deps"
         run: "mix local.hex --force && mix local.rebar --force && mix deps.get && mix deps.compile"
       - name: "Build"

--- a/.github/workflows/build-and-test-asdf.yml
+++ b/.github/workflows/build-and-test-asdf.yml
@@ -1,0 +1,34 @@
+name: Build and test ASDF
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request: []
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      MIX_ENV: test
+    name: Erlang ${{matrix.otp}} / Elixir ${{matrix.elixir}}
+    strategy:
+      matrix:
+        otp: ["25.0.2"]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{matrix.otp}}
+      - uses: asdf-vm/actions/install@v1
+        with:
+          command: asdf install elixir 1.13.4-otp-25
+      - name: "Get and compile deps"
+        run: "mix local.hex --force && mix local.rebar --force && mix deps.get && mix deps.compile"
+      - name: "Build"
+        run: "mix compile --warnings-as-errors"
+      - name: "Build escript"
+        run: "mix escript.build & mix escript.install"
+      - name: "Test"
+        run: "mix test test/gradient_cli_test.exs"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,4 +36,4 @@ jobs:
       - name: "Build"
         run: "mix compile --warnings-as-errors"
       - name: "Test"
-        run: "mix test"
+        run: "mix test --exclude requires_asdf"

--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -158,6 +158,11 @@ defmodule Gradient.CLI do
         Logger.error("Elixir is not managed by ASDF, #{inspect(ASDFError)}")
       end
       Path.wildcard(elixir_bin |> Path.dirname() |> Path.dirname() |> Path.join("lib/*/ebin"))
+      |> Enum.map(fn path ->
+        path
+        |> Path.expand()
+        |> to_charlist()
+      end)
       |> :code.add_paths()
     end
   end

--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -150,21 +150,20 @@ defmodule Gradient.CLI do
       end)
       |> :code.add_paths()
     else
-      {elixir_bin, 0} =
-        try do
-          System.cmd("asdf", ["which", "elixir"])
-        rescue
-          ASDFError ->
-            Logger.error("Elixir is not managed by ASDF, #{inspect(ASDFError)}")
-        end
+      try do
+        {elixir_bin, 0} = System.cmd("asdf", ["which", "elixir"])
 
-      Path.wildcard(elixir_bin |> Path.dirname() |> Path.dirname() |> Path.join("lib/*/ebin"))
-      |> Enum.map(fn path ->
-        path
-        |> Path.expand()
-        |> to_charlist()
-      end)
-      |> :code.add_paths()
+        Path.wildcard(elixir_bin |> Path.dirname() |> Path.dirname() |> Path.join("lib/*/ebin"))
+        |> Enum.map(fn path ->
+          path
+          |> Path.expand()
+          |> to_charlist()
+        end)
+        |> :code.add_paths()
+      rescue
+        ASDFError ->
+          Logger.error("Elixir is not managed by ASDF, #{inspect(ASDFError)}")
+      end
     end
   end
 

--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -223,7 +223,7 @@ defmodule Gradient.CLI do
       |> :code.add_paths()
     rescue
       ASDFError ->
-        Logger.error("Elixir is not managed by ASDF, #{inspect(ASDFError)}")
+        IO.puts("Elixir is not managed by ASDF, #{inspect(ASDFError)}")
     end
   end
 end

--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -72,6 +72,7 @@ defmodule Gradient.CLI do
       # We don't want to worry the user with the stop message, though.
       Logger.configure(level: :warning)
       Application.stop(:gradualizer)
+      check_asdf_paths()
       maybe_path_add(options)
       # Start Gradualizer application
       Application.ensure_all_started(:gradualizer)
@@ -149,21 +150,6 @@ defmodule Gradient.CLI do
         |> to_charlist()
       end)
       |> :code.add_paths()
-    else
-      try do
-        {elixir_bin, 0} = System.cmd("asdf", ["which", "elixir"])
-
-        Path.wildcard(elixir_bin |> Path.dirname() |> Path.dirname() |> Path.join("lib/*/ebin"))
-        |> Enum.map(fn path ->
-          path
-          |> Path.expand()
-          |> to_charlist()
-        end)
-        |> :code.add_paths()
-      rescue
-        ASDFError ->
-          Logger.error("Elixir is not managed by ASDF, #{inspect(ASDFError)}")
-      end
     end
   end
 
@@ -221,6 +207,23 @@ defmodule Gradient.CLI do
 
       true ->
         false
+    end
+  end
+
+  defp check_asdf_paths() do
+    try do
+      {elixir_bin, 0} = System.cmd("asdf", ["which", "elixir"])
+
+      Path.wildcard(elixir_bin |> Path.dirname() |> Path.dirname() |> Path.join("lib/*/ebin"))
+      |> Enum.map(fn path ->
+        path
+        |> Path.expand()
+        |> to_charlist()
+      end)
+      |> :code.add_paths()
+    rescue
+      ASDFError ->
+        Logger.error("Elixir is not managed by ASDF, #{inspect(ASDFError)}")
     end
   end
 end

--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -1,5 +1,4 @@
 defmodule Gradient.CLI do
-
   require Logger
 
   @moduledoc """
@@ -151,12 +150,14 @@ defmodule Gradient.CLI do
       end)
       |> :code.add_paths()
     else
-      {elixir_bin, 0} = try do
-        System.cmd("asdf", ["which", "elixir"])
-      rescue
-        ASDFError ->
-        Logger.error("Elixir is not managed by ASDF, #{inspect(ASDFError)}")
-      end
+      {elixir_bin, 0} =
+        try do
+          System.cmd("asdf", ["which", "elixir"])
+        rescue
+          ASDFError ->
+            Logger.error("Elixir is not managed by ASDF, #{inspect(ASDFError)}")
+        end
+
       Path.wildcard(elixir_bin |> Path.dirname() |> Path.dirname() |> Path.join("lib/*/ebin"))
       |> Enum.map(fn path ->
         path

--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -1,4 +1,7 @@
 defmodule Gradient.CLI do
+
+  require Logger
+
   @moduledoc """
   Gradient CLI module responsible for
   accepting shell params and starting gradualizer.
@@ -146,6 +149,15 @@ defmodule Gradient.CLI do
         |> Path.expand()
         |> to_charlist()
       end)
+      |> :code.add_paths()
+    else
+      {elixir_bin, 0} = try do
+        System.cmd("asdf", ["which", "elixir"])
+      rescue
+        ASDFError ->
+        Logger.error("Elixir is not managed by ASDF, #{inspect(ASDFError)}")
+      end
+      Path.wildcard(elixir_bin |> Path.dirname() |> Path.dirname() |> Path.join("lib/*/ebin"))
       |> :code.add_paths()
     end
   end

--- a/test/gradient_cli_test.exs
+++ b/test/gradient_cli_test.exs
@@ -2,7 +2,7 @@ defmodule Gradient.CLITest do
   use ExUnit.Case
 
   @tag :requires_asdf
-  test "--path-add option" do
+  test "Gradient escript detects asdf-installed Elixir libs" do
     {_, code} = System.cmd("sh", ["-c", "./gradient test/examples/1.12/range_step.ex"])
 
     assert 0 == code

--- a/test/gradient_cli_test.exs
+++ b/test/gradient_cli_test.exs
@@ -1,4 +1,3 @@
-
 defmodule Gradient.CLITest do
   use ExUnit.Case
 

--- a/test/gradient_cli_test.exs
+++ b/test/gradient_cli_test.exs
@@ -1,11 +1,9 @@
 defmodule Gradient.CLITest do
   use ExUnit.Case
 
+  @tag :requires_asdf
   test "--path-add option" do
-    {_, code} =
-      System.cmd("sh", ["-c", "./gradient test/examples/1.12/range_step.ex"]) |> IO.inspect()
-
-    # {_, code} = System.cmd("./gradient", ["test/examples/1.12/range_step.ex"])
+    {_, code} = System.cmd("./gradient", ["test/examples/1.12/range_step.ex"])
 
     assert 0 == code
   end

--- a/test/gradient_cli_test.exs
+++ b/test/gradient_cli_test.exs
@@ -1,0 +1,13 @@
+
+defmodule Gradient.CLITest do
+  use ExUnit.Case
+
+  test "--path-add option" do
+    {_, code} =
+      System.cmd("sh", ["-c", "./gradient test/examples/1.12/range_step.ex"]) |> IO.inspect()
+
+    # {_, code} = System.cmd("./gradient", ["test/examples/1.12/range_step.ex"])
+
+    assert 0 == code
+  end
+end

--- a/test/gradient_cli_test.exs
+++ b/test/gradient_cli_test.exs
@@ -3,7 +3,7 @@ defmodule Gradient.CLITest do
 
   @tag :requires_asdf
   test "--path-add option" do
-    {_, code} = System.cmd("./gradient", ["test/examples/1.12/range_step.ex"])
+    {_, code} = System.cmd("sh", ["-c", "./gradient test/examples/1.12/range_step.ex"])
 
     assert 0 == code
   end


### PR DESCRIPTION
When using escript, autodetect `asdf` and add its paths. 