### PR TITLE
Ignore

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,0 +1,4 @@
+[
+  {"lib/gradient/type_annotation.ex", :no_return},
+  {"lib/gradient/type_annotation.ex", :call_without_opaque}
+]

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,3 +37,6 @@ jobs:
         run: "mix compile --warnings-as-errors"
       - name: "Test"
         run: "mix test --exclude requires_asdf"
+      - if: ${{ matrix.elixir == '1.13.4' }}
+        name: "Gradient"
+        run: "mix gradient --fmt-location brief"

--- a/.gradient_ignore.exs
+++ b/.gradient_ignore.exs
@@ -1,0 +1,17 @@
+[
+  ## still to be fixed
+
+  # ?
+  {"lib/gradient/elixir_type.ex:70", {:type_error, :mismatch}},
+
+  # https://github.com/esl/gradient/issues/85
+  {:type_error, :unreachable_clause},
+
+  # https://github.com/esl/gradient/issues/37
+  {:type_error, :cyclic_type_vars},
+
+  ## ignores below are fixed in open PRs
+
+  # https://github.com/esl/gradient/pull/118
+  "test/support/ast_data.ex"
+]

--- a/.gradient_ignore.exs
+++ b/.gradient_ignore.exs
@@ -16,6 +16,9 @@
 
   "lib/gradient.ex:184",
 
+  # error occurs only on GitHub Actions
+  "test/support/helpers.ex:14",
+
   # https://github.com/esl/gradient/issues/85
   {:type_error, :unreachable_clause},
 

--- a/.gradient_ignore.exs
+++ b/.gradient_ignore.exs
@@ -4,6 +4,18 @@
   # ?
   {"lib/gradient/elixir_type.ex:70", {:type_error, :mismatch}},
 
+  "lib/gradient/elixir_type.ex:38",
+
+  "lib/gradient/debug.ex:58",
+
+  "lib/gradient/ast_specifier.ex:436",
+
+  "lib/gradient/elixir_fmt.ex:215",
+
+  "lib/gradient.ex:77",
+
+  "lib/gradient.ex:184",
+
   # https://github.com/esl/gradient/issues/85
   {:type_error, :unreachable_clause},
 

--- a/.gradient_ignore.exs
+++ b/.gradient_ignore.exs
@@ -6,11 +6,7 @@
 
   "lib/gradient/elixir_type.ex:38",
 
-  "lib/gradient/debug.ex:58",
-
   "lib/gradient/ast_specifier.ex:436",
-
-  "lib/gradient/elixir_fmt.ex:215",
 
   "lib/gradient.ex:77",
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,30 @@ Also, did we mention the analysis process is lightning fast?
 
 The `examples/` folder contains example applications showing how the produced error messages look like.
 
+### Ignore warnings
+
+It's possible to ignore specific warnings, by adding a `.gradient_ignore.exs` in project root folder.
+
+`.gradient_ignore.exs` contains a list of ignores:
+
+```elixir
+  [
+    # Ignores all errors in a file
+    "lib/ecto/changeset.ex",
+
+    # Ignores errors in a specific line in a file
+    "lib/ecto/schema.ex:55",
+
+    # Ignores an error kind in a file
+    {"lib/ecto/changeset.ex", {:spec_error, :mixed_specs}},
+
+    # Ignores an error kind in a specific line
+    {"lib/ecto/changeset.ex:55", {:spec_error, :mixed_specs}},
+
+    # Ignores an error kind in all files
+    {:spec_error, :mixed_specs}
+  ]
+```
 
 ## Caveats
 

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ The `examples/` folder contains example applications showing how the produced er
 
 ### Ignore warnings
 
-It's possible to ignore specific warnings, by adding a `.gradient_ignore.exs` in project root folder.
+It's possible to ignore specific warnings by adding a `.gradient_ignore.exs` in a project root folder.
 
-`.gradient_ignore.exs` contains a list of ignores:
+`.gradient_ignore.exs` should contain a list of ignore rules:
 
 ```elixir
   [

--- a/lib/gradient.ex
+++ b/lib/gradient.ex
@@ -33,85 +33,78 @@ defmodule Gradient do
   @doc """
   Type-checks file in `path` with provided `opts`, and prints the result.
   """
-  @spec type_check_file(charlist() | String.t(), options()) :: :ok | {:error, [error(), ...]}
+  @spec type_check_file(charlist() | String.t(), options()) :: [:ok | {:error, [error(), ...]}]
   def type_check_file(path, opts \\ []) do
     opts = Keyword.put(opts, :return_errors, true)
     module = Keyword.get(opts, :module, "all_modules")
 
     with {:ok, asts} <- ElixirFileUtils.get_forms(path, module),
-         {:ok, first_ast} <- get_first_forms(asts),
-         {:elixir, _} <- wrap_language_name(first_ast) do
-      asts
-      |> Enum.map(fn ast ->
-        ast =
-          ast
-          |> put_source_path(opts)
-          |> maybe_specify_forms(opts)
+         {:ok, first_ast} <- get_first_forms(asts) do
+      case wrap_language_name(first_ast) do
+        {:elixir, _} ->
+          Enum.map(asts, &handle_elixir_ast(&1, opts))
 
-        tokens = maybe_use_tokens(ast, opts)
-        opts = [{:env, build_env(tokens)} | opts]
-
-        case maybe_gradient_check(ast, opts) ++
-               maybe_gradualizer_check(ast, opts) do
-          [] ->
-            :ok
-
-          errors ->
-            opts = Keyword.put(opts, :forms, ast)
-            ElixirFmt.print_errors(errors, opts)
-
-            {:error, errors}
-        end
-      end)
-  # @spec type_check_file(charlist() | String.t(), options()) :: :ok | {:error, [error(), ...]}
-  # def type_check_file(path, opts \\ []) do
-  #   opts = Keyword.put(opts, :return_errors, true)
-
-  #   with {:ok, forms} <- ElixirFileUtils.get_forms(path),
-  #        {:elixir, _} <- wrap_language_name(forms) do
-  #     forms = maybe_specify_forms(forms, opts)
-
-  #     case maybe_gradient_check(forms, opts) ++ maybe_gradualizer_check(forms, opts) do
-  #       [] ->
-  #         :ok
-
-  #       errors ->
-  #         opts = Keyword.put(opts, :forms, forms)
-
-  #         case Error.reject_ignored_errors(errors, opts) do
-  #           [] ->
-  #             :ok
-
-  #           [_ | _] = filtered_errors ->
-  #             ElixirFmt.print_errors(filtered_errors, opts)
-  #             {:error, filtered_errors}
-  #         end
-  #     end
+        {:erlang, ast} ->
+          handle_erlang_ast(ast, opts)
+      end
     else
-      {:erlang, forms} ->
-        case maybe_gradualizer_check(forms, opts) do
-          [] ->
-            :ok
-          :nok ->
-            {:error, [:gradualizer_check_nok]}
-          errors ->
-            opts = Keyword.put(opts, :forms, forms)
-            ElixirFmt.print_errors(errors, opts)
-            {:error, errors}
-        end
-
       {:error, :module_not_found} ->
         Logger.error("Can't find module specified by '--module' flag.")
-        {:error, [{:module_not_found, module}]}
+        [{:error, [{:module_not_found, module}]}]
 
       error ->
         Logger.error("Can't load file - #{inspect(error)}")
-        {:error, [error]}
+        [{:error, [error]}]
     end
   end
 
   def build_env(tokens) do
     %{tokens_present: tokens != [], macro_lines: Gradient.Tokens.find_macro_lines(tokens)}
+  end
+
+  @spec handle_elixir_ast(any(), Keyword.t()) :: :ok | {:error, [error(), ...]}
+  defp handle_elixir_ast(ast, opts) do
+    ast =
+      ast
+      |> put_source_path(opts)
+      |> maybe_specify_forms(opts)
+
+    tokens = maybe_use_tokens(ast, opts)
+    opts = [{:env, build_env(tokens)} | opts]
+
+    case maybe_gradient_check(ast, opts) ++
+            maybe_gradualizer_check(ast, opts) do
+      [] ->
+        :ok
+
+      errors ->
+        opts = Keyword.put(opts, :forms, ast)
+        case Error.reject_ignored_errors(errors, opts) do
+          [] ->
+            :ok
+
+          [_ | _] = filtered_errors ->
+            ElixirFmt.print_errors(filtered_errors, opts)
+            {:error, filtered_errors}
+        end
+    end
+  end
+
+  defp handle_erlang_ast(ast, opts) do
+    case maybe_gradualizer_check(ast, opts) do
+      [] ->
+        [:ok]
+
+      errors ->
+        case Error.reject_ignored_errors(errors, opts) do
+          [] ->
+            [:ok]
+
+          [_ | _] = filtered_errors ->
+            ElixirFmt.print_errors(filtered_errors, opts)
+            [{:error, filtered_errors}]
+        end
+    end
   end
 
   defp maybe_use_tokens(forms, opts) do

--- a/lib/gradient.ex
+++ b/lib/gradient.ex
@@ -73,12 +73,13 @@ defmodule Gradient do
     opts = [{:env, build_env(tokens)} | opts]
 
     case maybe_gradient_check(ast, opts) ++
-            maybe_gradualizer_check(ast, opts) do
+           maybe_gradualizer_check(ast, opts) do
       [] ->
         :ok
 
       errors ->
         opts = Keyword.put(opts, :forms, ast)
+
         case Error.reject_ignored_errors(errors, opts) do
           [] ->
             :ok

--- a/lib/gradient/debug.ex
+++ b/lib/gradient/debug.ex
@@ -46,7 +46,7 @@ defmodule Gradient.Debug do
   @doc ~S"""
   Return the Erlang AST of an Erlang or Elixir module.
   """
-  @spec erlang_ast(module()) :: {:ok, [erlang_form()]}
+  @spec erlang_ast(module()) :: {:ok, Gradient.ElixirFileUtils.abstract_forms()}
   def erlang_ast(mod) do
     result =
       mod

--- a/lib/gradient/elixir_fmt.ex
+++ b/lib/gradient/elixir_fmt.ex
@@ -212,7 +212,7 @@ defmodule Gradient.ElixirFmt do
   end
 
   def format_type_error(error, opts) do
-    :gradualizer_fmt.format_type_error(error, opts) ++ '\n'
+    "#{:gradualizer_fmt.format_type_error(error, opts)}\n"
   end
 
   def format_expr_type_error(expression, actual_type, expected_type, opts) do

--- a/lib/gradient/error.ex
+++ b/lib/gradient/error.ex
@@ -105,7 +105,7 @@ defmodule Gradient.Error do
     {"lib/ecto/changeset.ex:55", {:spec_error, :mixed_specs}},
 
     # Ignores an error kind in all files
-    {:spec_error, :mixed_specs},
+    {:spec_error, :mixed_specs}
   ]
   ```
 

--- a/lib/gradient/error.ex
+++ b/lib/gradient/error.ex
@@ -1,0 +1,486 @@
+defmodule Gradient.Error do
+  @moduledoc ~S"""
+  Provides error kind information and logic for ignoring errors.
+  """
+
+  require Logger
+
+  @type kind ::
+          :argument_length_mismatch
+          | :bad_type_annotation
+          | :call_undef
+          | :form_check_timeout
+          | :illegal_map_type
+          | :nonexhaustive
+          | {:not_exported, :remote_type}
+          | {:spec_error, spec_kind()}
+          | {:type_error, type_kind()}
+          | {:undef, undef_kind()}
+
+  @type spec_kind ::
+          :mixed_specs
+          | :wrong_spec_name
+
+  @type type_kind ::
+          :arith_error
+          | :badkey
+          | :call_arity
+          | :call_intersect
+          | :check_clauses
+          | :cons_pat
+          | :cyclic_type_vars
+          | :expected_fun_type
+          | :int_error
+          | :list
+          | :mismatch
+          | :no_type_match_intersection
+          | :non_number_argument_to_minus
+          | :non_number_argument_to_plus
+          | :op_type_too_precise
+          | :operator_pattern
+          | :pattern
+          | :receive_after
+          | :record_pattern
+          | :rel_error
+          | :relop
+          | :unary_error
+          | :unreachable_clause
+
+  @type undef_kind ::
+          :record
+          | :record_field
+          | :remote_type
+          | :user_type
+
+  @typedoc """
+  In addition to the error kinds defined in `kind()`,
+  ignores can also target entity error groups (e.g. `:type_error`),
+  and also `:unknown`, in case an error is not identified.
+  """
+  @type ignored_kind ::
+          kind()
+          | :not_exported
+          | :spec_error
+          | :type_error
+          | :undef
+          | :unknown
+
+  @typep ignore_rule ::
+           {:ignore_file, file :: charlist()}
+           | {:ignore_kind, ignored_kind()}
+           | {:ignore_file_kind, file :: charlist(), ignored_kind()}
+           | {:ignore_file_line, file :: charlist(), :erl_anno.line()}
+           | {:ignore_file_line_kind, file :: charlist(), :erl_anno.line(), ignored_kind()}
+
+  @typedoc """
+  Ignores all errors in a given file.
+
+  Example: `"lib/example/module.ex"`
+  """
+  @type ignored_file :: String.t()
+
+  @typedoc """
+  Ignores all errors in a given file and line.
+
+  Example: `"lib/example/module.ex:12"`
+  """
+  @type ignored_file_line :: String.t()
+
+  @typedoc """
+  `.gradient_ignore.exs` contains a list of
+  ignore values following this type definition.
+
+  ```
+  [
+    # Ignores errors in the whole file
+    "lib/ecto/changeset.ex",
+
+    # Ignores errors in a specific line in a file
+    "lib/ecto/schema.ex:55",
+
+    # Ignores an error kind in a file
+    {"lib/ecto/changeset.ex", {:spec_error, :mixed_specs}},
+
+    # Ignores an error kind in a specific line
+    {"lib/ecto/changeset.ex:55", {:spec_error, :mixed_specs}},
+
+    # Ignores an error kind in all files
+    {:spec_error, :mixed_specs},
+  ]
+  ```
+
+  The kind can be any of `ignored_kind()`.
+  """
+  @type ignore ::
+          ignored_file()
+          | ignored_file_line()
+          | {ignored_file(), line :: non_neg_integer()}
+          | {ignored_file() | ignored_file_line(), ignored_kind()}
+          | ignored_kind()
+
+  defguardp is_file(file) when is_binary(file) and byte_size(file) > 0
+  defguardp is_line(line) when is_integer(line) and line >= 0
+
+  @doc """
+  Returns a subset of the given `errors` list, considering
+  any ignores provided through `opts[:ignores]`.
+  """
+  @spec reject_ignored_errors([error], Keyword.t()) :: [error] when error: tuple()
+  def reject_ignored_errors(errors, opts)
+
+  def reject_ignored_errors([], _opts), do: []
+
+  def reject_ignored_errors(errors, opts) do
+    opts
+    |> ignores_option()
+    |> parse_applicable_ignores()
+    |> case do
+      [] ->
+        errors
+
+      [_ | _] = ignores ->
+        Enum.reject(errors, &ignore?(&1, ignores))
+    end
+  end
+
+  @doc """
+  Returns the kind of given `error`, or `:unknown`,
+  if error kind could not be detected.
+  """
+  @spec kind(tuple()) :: kind() | :unknown
+  def kind(error)
+
+  def kind({filename, error}) when is_list(filename) do
+    kind(error)
+  end
+
+  def kind({:argument_length_mismatch, _anno, _len_ty, _len_args}) do
+    :argument_length_mismatch
+  end
+
+  def kind({:bad_type_annotation, _type_lit}) do
+    :bad_type_annotation
+  end
+
+  def kind({:call_undef, _anno, _module, _func, _arity}) do
+    :call_undef
+  end
+
+  def kind({:form_check_timeout, _form}) do
+    :form_check_timeout
+  end
+
+  def kind({:illegal_map_type, _type}) do
+    :illegal_map_type
+  end
+
+  def kind({:nonexhaustive, _anno, _example}) do
+    :nonexhaustive
+  end
+
+  def kind({:not_exported, :remote_type, _anno, _mfa}) do
+    {:not_exported, :remote_type}
+  end
+
+  def kind({:spec_error, type, _anno, _name, _arity})
+      when type in [:mixed_specs, :wrong_spec_name] do
+    {:spec_error, type}
+  end
+
+  def kind({:type_error, :arith_error, _arith_op, _anno, _ty}) do
+    {:type_error, :arith_error}
+  end
+
+  def kind({:type_error, :arith_error, _arith_op, _anno, _ty1, _ty2}) do
+    {:type_error, :arith_error}
+  end
+
+  def kind({:type_error, :badkey, _key_expr, _map_type}) do
+    {:type_error, :badkey}
+  end
+
+  def kind({:type_error, :call_arity, _anno, _fun, _ty_arity, _call_arity}) do
+    {:type_error, :call_arity}
+  end
+
+  def kind({:type_error, :call_intersect, _anno, _fun_ty, _name}) do
+    {:type_error, :call_intersect}
+  end
+
+  def kind({:type_error, :cyclic_type_vars, _anno, _ty, _xs}) do
+    {:type_error, :cyclic_type_vars}
+  end
+
+  def kind({:type_error, :cons_pat, _anno, _cons, _ty}) do
+    {:type_error, :cons_pat}
+  end
+
+  def kind({:type_error, :expected_fun_type, _anno, _fun, _fun_ty}) do
+    {:type_error, :expected_fun_type}
+  end
+
+  def kind({:type_error, :int_error, _arith_op, _anno, _ty1, _ty2}) do
+    {:type_error, :int_error}
+  end
+
+  def kind({:type_error, :list, _anno, _ty1, _ty}) do
+    {:type_error, :list}
+  end
+
+  def kind({:type_error, :list, _anno, _ty}) do
+    {:type_error, :list}
+  end
+
+  def kind({:type_error, :mismatch, _ty, _expr}) do
+    {:type_error, :mismatch}
+  end
+
+  def kind({:type_error, :no_type_match_intersection, _anno, _fun, _fun_ty}) do
+    {:type_error, :no_type_match_intersection}
+  end
+
+  def kind({:type_error, :non_number_argument_to_plus, _anno, _ty}) do
+    {:type_error, :non_number_argument_to_plus}
+  end
+
+  def kind({:type_error, :non_number_argument_to_minus, _anno, _ty}) do
+    {:type_error, :non_number_argument_to_minus}
+  end
+
+  def kind({:type_error, :op_type_too_precise, _op, _anno, _ty}) do
+    {:type_error, :op_type_too_precise}
+  end
+
+  def kind({:type_error, :operator_pattern, _pat, _ty}) do
+    {:type_error, :operator_pattern}
+  end
+
+  def kind({:type_error, :pattern, _anno, _pat, _ty}) do
+    {:type_error, :pattern}
+  end
+
+  def kind({:type_error, :receive_after, _anno, _ty_clauses, _ty_block}) do
+    {:type_error, :receive_after}
+  end
+
+  def kind({:type_error, :record_pattern, _anno, _record, _ty}) do
+    {:type_error, :record_pattern}
+  end
+
+  def kind({:type_error, :rel_error, _logic_op, _anno, _ty1, _ty2}) do
+    {:type_error, :rel_error}
+  end
+
+  def kind({:type_error, :relop, _rel_op, _anno, _ty1, _ty2}) do
+    {:type_error, :relop}
+  end
+
+  def kind({:type_error, :unary_error, _op, _anno, _target_ty, _ty}) do
+    {:type_error, :unary_error}
+  end
+
+  def kind({:type_error, :unreachable_clause, _anno}) do
+    {:type_error, :unreachable_clause}
+  end
+
+  def kind({:type_error, a, b, c})
+      when is_tuple(a) and is_tuple(b) and is_tuple(c) do
+    {:type_error, :mismatch}
+  end
+
+  def kind({:undef, type, _anno, _other})
+      when type in [:record, :record_field, :user_type, :remote_type] do
+    {:undef, type}
+  end
+
+  def kind({:undef, :record_field, _field_name}) do
+    {:undef, :record_field}
+  end
+
+  def kind(_other), do: :unknown
+
+  @doc """
+  Returns the line of given `error`, or `nil`,
+  if line could not be detected.
+  """
+  @spec line(error :: tuple()) :: nil | :erl_anno.line()
+  def line(error)
+
+  def line({filename, error}) when is_list(filename) and is_tuple(error) do
+    line(error)
+  end
+
+  def line({:argument_length_mismatch, anno, _, _}), do: gradualizer_line(anno)
+  def line({:call_undef, anno, _, _, _}), do: gradualizer_line(anno)
+  def line({:nonexhaustive, anno, _}), do: gradualizer_line(anno)
+  def line({:not_exported, _, anno, _}), do: gradualizer_line(anno)
+  def line({:spec_error, _, anno, _, _}), do: gradualizer_line(anno)
+  def line({:type_error, :arith_error, _, anno, _}), do: gradualizer_line(anno)
+  def line({:type_error, :arith_error, _, anno, _, _}), do: gradualizer_line(anno)
+  def line({:type_error, :call_arity, anno, _, _, _}), do: gradualizer_line(anno)
+  def line({:type_error, :call_intersect, anno, _, _}), do: gradualizer_line(anno)
+  def line({:type_error, :cyclic_type_vars, anno, _, _}), do: gradualizer_line(anno)
+  def line({:type_error, :cons_pat, anno, _, _}), do: gradualizer_line(anno)
+  def line({:type_error, :expected_fun_type, anno, _, _}), do: gradualizer_line(anno)
+  def line({:type_error, :int_error, _, anno, _, _}), do: gradualizer_line(anno)
+  def line({:type_error, :list, anno, _}), do: gradualizer_line(anno)
+  def line({:type_error, :list, anno, _, _}), do: gradualizer_line(anno)
+  def line({:type_error, :no_type_match_intersection, anno, _, _}), do: gradualizer_line(anno)
+  def line({:type_error, :non_number_argument_to_plus, anno, _}), do: gradualizer_line(anno)
+  def line({:type_error, :non_number_argument_to_minus, anno, _}), do: gradualizer_line(anno)
+  def line({:type_error, :receive_after, anno, _, _}), do: gradualizer_line(anno)
+  def line({:type_error, :record_pattern, anno, _, _}), do: gradualizer_line(anno)
+  def line({:type_error, :rel_error, _, anno, _, _}), do: gradualizer_line(anno)
+  def line({:type_error, :relop, _, anno, _, _}), do: gradualizer_line(anno)
+  def line({:type_error, {_, anno, _}, _, _}), do: gradualizer_line(anno)
+  def line({:type_error, {_, anno, _, _}, _, _}), do: gradualizer_line(anno)
+
+  def line({:type_error, expression, _actual, _expected})
+      when is_tuple(expression) do
+    gradualizer_line(expression)
+  end
+
+  def line({:undef, _, anno, _}), do: gradualizer_line(anno)
+
+  def line(_), do: nil
+
+  defp gradualizer_line(anno_or_expr) do
+    anno_or_expr
+    |> :gradualizer_fmt.format_location(:brief)
+    |> List.first()
+    |> case do
+      [_ | _] = line ->
+        :erlang.list_to_integer(line)
+
+      _ ->
+        nil
+    end
+  end
+
+  @spec ignore?(error :: tuple(), [ignore_rule(), ...]) :: boolean()
+  defp ignore?({path, error}, [_ | _] = ignores)
+       when is_binary(path) and is_tuple(error) do
+    ignore?({to_charlist(path), error}, ignores)
+  end
+
+  defp ignore?({filename, error}, [_ | _] = ignores)
+       when is_list(filename) and is_tuple(error) do
+    kind = kind(error)
+    Enum.any?(ignores, &ignore?(&1, {filename, error}, kind))
+  end
+
+  @spec ignore?(
+          ignore_rule(),
+          {file :: charlist(), error :: tuple()},
+          kind() | :unknown
+        ) :: boolean()
+  defp ignore?({:ignore_file, file}, {file, _error}, _kind), do: true
+  defp ignore?({:ignore_kind, kind}, {_file, _error}, {kind, _}), do: true
+  defp ignore?({:ignore_kind, kind}, {_file, _error}, kind), do: true
+  defp ignore?({:ignore_file_kind, file, kind}, {file, _error}, {kind, _}), do: true
+  defp ignore?({:ignore_file_kind, file, kind}, {file, _error}, kind), do: true
+
+  defp ignore?({:ignore_file_line, file, line}, {file, error}, _kind) do
+    line(error) == line
+  end
+
+  defp ignore?({:ignore_file_line_kind, file, line, kind}, {file, error}, {kind, _}) do
+    line(error) == line
+  end
+
+  defp ignore?({:ignore_file_line_kind, file, line, kind}, {file, error}, kind) do
+    line(error) == line
+  end
+
+  defp ignore?(_ignore, _file_error, _kind), do: false
+
+  @spec ignores_option(Keyword.t()) :: [ignore() | any()]
+  defp ignores_option(opts) do
+    case opts[:ignores] do
+      nil ->
+        []
+
+      ignores when is_list(ignores) ->
+        ignores
+    end
+  end
+
+  @spec parse_applicable_ignores([ignore() | any()]) :: [ignore_rule()]
+  defp parse_applicable_ignores(ignores) when is_list(ignores) do
+    ignores
+    |> Enum.map(fn
+      {file, line} when is_file(file) and is_line(line) ->
+        {:ignore_file_line, to_charlist(file), line}
+
+      {value, kind_atom} when is_binary(value) and is_atom(kind_atom) ->
+        case file_or_file_line(value) do
+          nil ->
+            nil
+
+          {file, line} ->
+            {:ignore_file_line_kind, file, line, kind_atom}
+
+          file ->
+            {:ignore_file_kind, file, kind_atom}
+        end
+
+      {value, {kind_meta, kind_detail}}
+      when is_binary(value) and is_atom(kind_meta) and is_atom(kind_detail) ->
+        case file_or_file_line(value) do
+          nil ->
+            nil
+
+          {file, line} ->
+            {:ignore_file_line_kind, file, line, {kind_meta, kind_detail}}
+
+          file ->
+            {:ignore_file_kind, file, {kind_meta, kind_detail}}
+        end
+
+      value when is_binary(value) ->
+        case file_or_file_line(value) do
+          nil ->
+            nil
+
+          {file, line} ->
+            {:ignore_file_line, file, line}
+
+          file ->
+            {:ignore_file, file}
+        end
+
+      kind_atom when is_atom(kind_atom) ->
+        {:ignore_kind, kind_atom}
+
+      {kind_meta, kind_detail} when is_atom(kind_meta) and is_atom(kind_detail) ->
+        {:ignore_kind, {kind_meta, kind_detail}}
+
+      _ ->
+        nil
+    end)
+    |> Enum.filter(& &1)
+  end
+
+  @spec file_or_file_line(String.t()) ::
+          nil
+          | (filename :: charlist())
+          | {filename :: charlist(), line :: :erl_anno.line()}
+  defp file_or_file_line(value) when is_binary(value) do
+    case String.split(value, ":") do
+      [file, line] when is_file(file) ->
+        case Integer.parse(line) do
+          {x, ""} when is_integer(x) and x >= 0 ->
+            {to_charlist(file), x}
+
+          _ ->
+            nil
+        end
+
+      [file] when is_file(file) ->
+        to_charlist(file)
+
+      _ ->
+        nil
+    end
+  end
+end

--- a/lib/gradient/error.ex
+++ b/lib/gradient/error.ex
@@ -297,7 +297,10 @@ defmodule Gradient.Error do
     {:undef, :record_field}
   end
 
-  def kind(_other), do: :unknown
+  def kind(other) do
+    Logger.debug("Could not determine kind of error: #{inspect(other)}")
+    :unknown
+  end
 
   @doc """
   Returns the line of given `error`, or `nil`,
@@ -337,12 +340,16 @@ defmodule Gradient.Error do
 
   def line({:type_error, expression, _actual, _expected})
       when is_tuple(expression) do
-    gradualizer_line(expression)
+    IO.inspect(expression, label: :expr)
+    gradualizer_line(expression) |> IO.inspect(label: :res)
   end
 
   def line({:undef, _, anno, _}), do: gradualizer_line(anno)
 
-  def line(_), do: nil
+  def line(other) do
+    Logger.debug("Gradient could not determine line of error: #{inspect(other)}")
+    nil
+  end
 
   defp gradualizer_line(anno_or_expr) do
     anno_or_expr

--- a/lib/gradient/error.ex
+++ b/lib/gradient/error.ex
@@ -335,6 +335,7 @@ defmodule Gradient.Error do
   def line({:type_error, :record_pattern, anno, _, _}), do: gradualizer_line(anno)
   def line({:type_error, :rel_error, _, anno, _, _}), do: gradualizer_line(anno)
   def line({:type_error, :relop, _, anno, _, _}), do: gradualizer_line(anno)
+  def line({:type_error, :pattern, _, anno, _}), do: gradualizer_line(anno)
   def line({:type_error, {_, anno, _}, _, _}), do: gradualizer_line(anno)
   def line({:type_error, {_, anno, _, _}, _, _}), do: gradualizer_line(anno)
 

--- a/lib/mix/tasks/gradient.ex
+++ b/lib/mix/tasks/gradient.ex
@@ -31,7 +31,10 @@ defmodule Mix.Tasks.Gradient do
     * `--underscore-color ansicode` - set color for the underscored invalid code part
       in the fancy messages
 
-  Warning! Flags passed to this task are passed on to Gradualizer.
+  _Warning!_ Flags passed to this task are passed on to Gradualizer.
+
+  To ignore errors, define a `.gradient_ignore.exs` in the project root folder.
+  Check `Gradient.Error` `ignore()` type for more details.
   """
   @shortdoc "Runs gradient with default or given options"
 
@@ -64,6 +67,8 @@ defmodule Mix.Tasks.Gradient do
   def run(args) do
     {options, user_paths, _invalid} = OptionParser.parse(args, strict: @options)
 
+    ignores = fetch_ignores()
+
     options = Enum.reduce(options, [], &prepare_option/2)
 
     # Load dependencies
@@ -79,7 +84,13 @@ defmodule Mix.Tasks.Gradient do
 
     files
     |> Stream.map(fn {app_path, paths} ->
-      Stream.map(paths, &Gradient.type_check_file(&1, [{:app_path, app_path} | options]))
+      Stream.map(
+        paths,
+        &Gradient.type_check_file(
+          &1,
+          [{:app_path, app_path}, {:ignores, ignores} | options]
+        )
+      )
     end)
     |> Stream.concat()
     |> execute(options)
@@ -229,6 +240,23 @@ defmodule Mix.Tasks.Gradient do
       |> Enum.map(fn {app_name, _} -> to_charlist(compile_path(app_name)) end)
     else
       [to_charlist(Mix.Project.compile_path())]
+    end
+  end
+
+  @spec fetch_ignores() :: [term()]
+  defp fetch_ignores() do
+    case File.read(".gradient_ignore.exs") do
+      {:ok, content} ->
+        case Code.eval_string(content) do
+          {[_ | _] = ignores, _binding} ->
+            ignores
+
+          _ ->
+            []
+        end
+
+      {:error, _} ->
+        []
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule Gradient.MixProject do
     [
       {:gradualizer, github: "josefs/Gradualizer", ref: "ba5481c", manager: :rebar3},
       # {:gradualizer, path: "../Gradualizer/", manager: :rebar3},
-      {:dialyxir, "~> 1.0", only: [:dev], runtime: false},
+      {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.28.4", only: [:dev], runtime: false}
     ]
   end

--- a/test/gradient/error_test.exs
+++ b/test/gradient/error_test.exs
@@ -1,0 +1,281 @@
+defmodule Gradient.ErrorTest do
+  use ExUnit.Case, async: true
+  import ExUnit.CaptureIO
+  alias Gradient.Error
+
+  ## Kinds missing examples:
+  #
+  # - argument_length_mismatch
+  # - bad_type_annotation
+  # - form_check_timeout
+  # - illegal_map_type
+  # - nonexhaustive
+  # - {not_exported, remote_type}
+  # - {type_error, badkey}
+  # - {type_error, call_arity}
+  # - {type_error, call_intersect}
+  # - {type_error, check_clauses}
+  # - {type_error, cons_pat}
+  # - {type_error, cyclic_type_vars}
+  # - {type_error, expected_fun_type}
+  # - {type_error, int_error}
+  # - {type_error, list}
+  # - {type_error, no_type_match_intersection}
+  # - {type_error, non_number_argument_to_minus}
+  # - {type_error, non_number_argument_to_plus}
+  # - {type_error, op_type_too_precise}
+  # - {type_error, operator_pattern}
+  # - {type_error, pattern}
+  # - {type_error, receive_after}
+  # - {type_error, record_pattern}
+  # - {type_error, rel_error}
+  # - {type_error, relop}
+  # - {type_error, unary_error}
+  # - {undef, record}
+  # - {undef, record_field}
+  # - {undef, remote_type}
+  # - {undef, user_type}
+
+  @examples [
+    basic: [],
+    "basic/atom": [],
+    "basic/binary": [],
+    "basic/char": [],
+    "basic/charlist": [],
+    "basic/float": [],
+    "basic/int": [],
+    "basic/string": [],
+    call: [],
+    call_remote_exception: [
+      {8, :call_undef}
+    ],
+    "conditional/case": [],
+    "conditional/cond": [],
+    "conditional/guards": [],
+    "conditional/if": [],
+    "conditional/unless": [],
+    "conditional/with": [
+      {12, {:type_error, :mismatch}}
+    ],
+    list: [],
+    list_comprehension: [],
+    map: [],
+    pipe_op: [],
+    receive: [],
+    "record/record": [],
+    simple_app: [
+      {31, {:type_error, :mismatch}}
+    ],
+    simple_range: [],
+    spec_correct: [
+      {nil, {:type_error, :unreachable_clause}},
+      {nil, {:type_error, :unreachable_clause}}
+    ],
+    spec_default_args: [],
+    spec_mixed: [
+      {3, {:spec_error, :mixed_specs}},
+      {3, {:spec_error, :wrong_spec_name}},
+      {nil, {:type_error, :unreachable_clause}}
+    ],
+    spec_wrong_name: [
+      {3, {:type_error, :arith_error}},
+      {5, {:spec_error, :wrong_spec_name}},
+      {8, {:type_error, :mismatch}},
+      {11, {:spec_error, :wrong_spec_name}}
+    ],
+    spec_wrong_args_arity: [
+      {2, {:spec_error, :wrong_spec_name}}
+    ],
+    string_example: [
+      {18, {:type_error, :mismatch}}
+    ],
+    "struct/struct": [],
+    try: [
+      {44, {:type_error, :mismatch}}
+    ],
+    tuple: [],
+    "type/list_infer": [],
+    "type/record": [
+      {8, {:type_error, :mismatch}},
+      {11, {:type_error, :mismatch}},
+      {14, {:type_error, :mismatch}}
+    ],
+    "type/s_wrong_ret": [
+      {3, {:type_error, :mismatch}},
+      {6, {:type_error, :mismatch}}
+    ],
+    "type/wrong_ret": [
+      {3, {:type_error, :mismatch}},
+      {6, {:type_error, :mismatch}},
+      {9, {:type_error, :mismatch}},
+      {15, {:type_error, :mismatch}},
+      {18, {:type_error, :mismatch}},
+      {21, {:type_error, :mismatch}},
+      {24, {:type_error, :mismatch}},
+      {27, {:type_error, :mismatch}},
+      {31, {:type_error, :mismatch}},
+      {35, {:type_error, :mismatch}},
+      {41, {:type_error, :mismatch}},
+      {45, {:type_error, :mismatch}},
+      {50, {:type_error, :mismatch}},
+      {53, {:type_error, :mismatch}},
+      {56, {:type_error, :mismatch}},
+      {59, {:type_error, :mismatch}},
+      {62, {:type_error, :mismatch}},
+      {65, {:type_error, :mismatch}},
+      {68, {:type_error, :mismatch}},
+      {71, {:type_error, :mismatch}},
+      {74, {:type_error, :mismatch}},
+      {77, {:type_error, :mismatch}},
+      {80, :unknown}
+    ],
+    typespec: [
+      {6, {:undef, :remote_type}},
+      {12, {:undef, :remote_type}},
+      {18, {:undef, :remote_type}}
+    ],
+    typespec_beh: [],
+    typespec_when: []
+  ]
+
+  test "kinds match examples" do
+    for {example, expected_result} <- @examples do
+      actual_result = example |> path() |> errors() |> compact()
+      assert {_, ^actual_result} = {example, expected_result}
+    end
+  end
+
+  describe "reject_ignored_errors/2" do
+    test "ignores nothing when there's no opts[:ignores]" do
+      path = path(:typespec)
+      assert [_ | _] = errors = errors(path)
+      assert ^errors = Error.reject_ignored_errors(errors, [])
+    end
+
+    test "ignores all errors of a file" do
+      path = path(:typespec)
+      assert [_ | _] = errors = errors(path)
+      assert [] = reject(errors, path)
+    end
+
+    test "ignores errors on a file line" do
+      path = path(:typespec)
+      errors = errors(path)
+
+      assert [6, 12, 18] = error_lines(errors)
+
+      assert [6, 18] = errors |> reject({path, 12}) |> error_lines()
+      assert [6, 12] = errors |> reject("#{path}:18") |> error_lines()
+    end
+
+    test "ignores errors by kind" do
+      path = path(:spec_wrong_name)
+      errors = errors(path)
+
+      reject_compact = &compact(reject(errors, &1))
+
+      assert compact(errors) == [
+               {3, {:type_error, :arith_error}},
+               {5, {:spec_error, :wrong_spec_name}},
+               {8, {:type_error, :mismatch}},
+               {11, {:spec_error, :wrong_spec_name}}
+             ]
+
+      # ignoring all occurrences of an error
+      assert reject_compact.({:spec_error, :wrong_spec_name}) == [
+               {3, {:type_error, :arith_error}},
+               {8, {:type_error, :mismatch}}
+             ]
+
+      # ignoring all occurrences of another error
+      assert reject_compact.({:type_error, :arith_error}) == [
+               {5, {:spec_error, :wrong_spec_name}},
+               {8, {:type_error, :mismatch}},
+               {11, {:spec_error, :wrong_spec_name}}
+             ]
+
+      # ignoring all occurrences of error group
+      assert reject_compact.(:type_error) == [
+               {5, {:spec_error, :wrong_spec_name}},
+               {11, {:spec_error, :wrong_spec_name}}
+             ]
+
+      # ignoring all occurrences of an error on a file
+      assert reject_compact.({path, {:spec_error, :wrong_spec_name}}) == [
+               {3, {:type_error, :arith_error}},
+               {8, {:type_error, :mismatch}}
+             ]
+
+      # ignoring all occurrences of another error on a file
+      assert reject_compact.({path, {:type_error, :arith_error}}) == [
+               {5, {:spec_error, :wrong_spec_name}},
+               {8, {:type_error, :mismatch}},
+               {11, {:spec_error, :wrong_spec_name}}
+             ]
+
+      # ignoring all occurrences of error group on a file
+      assert reject_compact.({path, :type_error}) == [
+               {5, {:spec_error, :wrong_spec_name}},
+               {11, {:spec_error, :wrong_spec_name}}
+             ]
+
+      # ignoring all occurrences of an error on a file line
+      assert reject_compact.({"#{path}:5", {:spec_error, :wrong_spec_name}}) == [
+               {3, {:type_error, :arith_error}},
+               {8, {:type_error, :mismatch}},
+               {11, {:spec_error, :wrong_spec_name}}
+             ]
+
+      # ignoring all occurrences of an error group on a file line
+      assert reject_compact.({"#{path}:3", :type_error}) == [
+               {5, {:spec_error, :wrong_spec_name}},
+               {8, {:type_error, :mismatch}},
+               {11, {:spec_error, :wrong_spec_name}}
+             ]
+    end
+  end
+
+  defp compact(errors) do
+    errors
+    |> Enum.map(&{Error.line(&1), Error.kind(&1)})
+    |> Enum.sort_by(&elem(&1, 0))
+  end
+
+  defp error_lines(errors) do
+    errors |> Enum.map(&Error.line/1) |> Enum.sort()
+  end
+
+  defp reject(errors, ignore) do
+    Error.reject_ignored_errors(errors, ignores: [ignore])
+  end
+
+  defp path(example) do
+    Path.join(["test", "examples", "#{example}.ex"])
+  end
+
+  defp errors(path) do
+    pid = self()
+    ref = make_ref()
+
+    _ =
+      capture_io(fn ->
+        capture_io(:stderr, fn ->
+          errors =
+            case Gradient.type_check_file(path) do
+              :ok ->
+                []
+
+              {:error, errors} when is_list(errors) ->
+                errors
+            end
+
+          send(pid, {:errors, ref, errors})
+        end)
+      end)
+
+    receive do
+      {:errors, ^ref, errors} ->
+        errors
+    end
+  end
+end

--- a/test/gradient/error_test.exs
+++ b/test/gradient/error_test.exs
@@ -67,15 +67,11 @@ defmodule Gradient.ErrorTest do
       {31, {:type_error, :mismatch}}
     ],
     simple_range: [],
-    spec_correct: [
-      {nil, {:type_error, :unreachable_clause}},
-      {nil, {:type_error, :unreachable_clause}}
-    ],
+    spec_correct: [],
     spec_default_args: [],
     spec_mixed: [
       {3, {:spec_error, :mixed_specs}},
       {3, {:spec_error, :wrong_spec_name}},
-      {nil, {:type_error, :unreachable_clause}}
     ],
     spec_wrong_name: [
       {3, {:type_error, :arith_error}},

--- a/test/gradient/error_test.exs
+++ b/test/gradient/error_test.exs
@@ -262,10 +262,10 @@ defmodule Gradient.ErrorTest do
         capture_io(:stderr, fn ->
           errors =
             case Gradient.type_check_file(path) do
-              :ok ->
+              [:ok] ->
                 []
 
-              {:error, errors} when is_list(errors) ->
+              [{:error, errors}] when is_list(errors) ->
                 errors
             end
 

--- a/test/gradient/error_test.exs
+++ b/test/gradient/error_test.exs
@@ -71,7 +71,7 @@ defmodule Gradient.ErrorTest do
     spec_default_args: [],
     spec_mixed: [
       {3, {:spec_error, :mixed_specs}},
-      {3, {:spec_error, :wrong_spec_name}},
+      {3, {:spec_error, :wrong_spec_name}}
     ],
     spec_wrong_name: [
       {3, {:type_error, :arith_error}},

--- a/test/gradient/type_annotation_test.exs
+++ b/test/gradient/type_annotation_test.exs
@@ -11,6 +11,7 @@ defmodule Gradient.TypeAnnotationTest do
     io_data =
       capture_io(fn ->
         assert [{:error, _}] = Gradient.type_check_file(path, @no_color)
+        # assert {:error, [_]} = Gradient.type_check_file(path, @no_color)
       end)
 
     assert String.contains?(io_data, "expected to have type nonempty_list")
@@ -22,6 +23,7 @@ defmodule Gradient.TypeAnnotationTest do
     io_data =
       capture_io(fn ->
         assert [{:error, _}] = Gradient.type_check_file(path, @no_color)
+        # assert {:error, [_]} = Gradient.type_check_file(path, @no_color)
       end)
 
     assert String.contains?(io_data, "expected to have type float")

--- a/test/gradient_test.exs
+++ b/test/gradient_test.exs
@@ -8,16 +8,12 @@ defmodule GradientTest do
     # typecheck file with errors
     path = "test/examples/erlang/_build/test_err.beam"
     erl_path = "test/examples/erlang/test_err.erl"
-    io_data = capture_io(fn -> assert {:error, _} = Gradient.type_check_file(path) end)
-    # io_data =
-    #   capture_io(fn ->
-    #     assert {:error, [:gradualizer_check_nok]} = Gradient.type_check_file(path)
-    #   end)
+    io_data = capture_io(fn -> assert [{:error, [{'test/examples/erlang/test_err.erl', {:type_error, _, _, _}}]}] = Gradient.type_check_file(path) end)
 
     assert String.contains?(io_data, erl_path)
     # typecheck correct file
     capture_io(fn ->
-      assert :ok = Gradient.type_check_file("test/examples/erlang/_build/test.beam")
+      assert [:ok] = Gradient.type_check_file("test/examples/erlang/_build/test.beam")
     end)
   end
 
@@ -28,8 +24,7 @@ defmodule GradientTest do
 
     io_data =
       capture_io(fn ->
-        assert [{:error, _}] = Gradient.type_check_file(path)
-        # assert {:error, [_ | _]} = Gradient.type_check_file(path)
+        assert [{:error, [_ | _]}] = Gradient.type_check_file(path)
       end)
 
     assert String.contains?(io_data, ex_path)

--- a/test/gradient_test.exs
+++ b/test/gradient_test.exs
@@ -9,6 +9,11 @@ defmodule GradientTest do
     path = "test/examples/erlang/_build/test_err.beam"
     erl_path = "test/examples/erlang/test_err.erl"
     io_data = capture_io(fn -> assert {:error, _} = Gradient.type_check_file(path) end)
+    # io_data =
+    #   capture_io(fn ->
+    #     assert {:error, [:gradualizer_check_nok]} = Gradient.type_check_file(path)
+    #   end)
+
     assert String.contains?(io_data, erl_path)
     # typecheck correct file
     capture_io(fn ->
@@ -24,6 +29,7 @@ defmodule GradientTest do
     io_data =
       capture_io(fn ->
         assert [{:error, _}] = Gradient.type_check_file(path)
+        # assert {:error, [_ | _]} = Gradient.type_check_file(path)
       end)
 
     assert String.contains?(io_data, ex_path)

--- a/test/gradient_test.exs
+++ b/test/gradient_test.exs
@@ -8,7 +8,12 @@ defmodule GradientTest do
     # typecheck file with errors
     path = "test/examples/erlang/_build/test_err.beam"
     erl_path = "test/examples/erlang/test_err.erl"
-    io_data = capture_io(fn -> assert [{:error, [{'test/examples/erlang/test_err.erl', {:type_error, _, _, _}}]}] = Gradient.type_check_file(path) end)
+
+    io_data =
+      capture_io(fn ->
+        assert [{:error, [{'test/examples/erlang/test_err.erl', {:type_error, _, _, _}}]}] =
+                 Gradient.type_check_file(path)
+      end)
 
     assert String.contains?(io_data, erl_path)
     # typecheck correct file

--- a/test/mix/tasks/gradient_test.exs
+++ b/test/mix/tasks/gradient_test.exs
@@ -219,7 +219,14 @@ defmodule Mix.Tasks.GradientTest do
     assert run_task([@examples_path <> "/dependent_modules.ex"]) =~ "No errors found!"
   end
 
-  def run_task(args), do: capture_io(fn -> Mix.Tasks.Gradient.run(args) end)
+  # def run_task(args), do: capture_io(fn -> Mix.Tasks.Gradient.run(args) end)
+  def run_task(args) do
+    capture_io(fn ->
+      capture_io(:stderr, fn ->
+        Mix.Tasks.Gradient.run(args)
+      end)
+    end)
+  end
 
   def test_opts(opts), do: ["--no-comile", "--no-deps"] ++ opts
 end


### PR DESCRIPTION
- Allow ignoring errors by file/line/error kind by adding them to `.gradient_ignore.exs`
- Fix some of the minor error gradient returns
- Add all of the unfixed gradient errors to the `.gradient_ignore.exs`