### PR TITLE
Add Debug helper for printing disassembled Elixir code

### DIFF
--- a/lib/gradient/debug.ex
+++ b/lib/gradient/debug.ex
@@ -87,7 +87,7 @@ defmodule Gradient.Debug do
       "defmodule ",
       inspect(module),
       " do\n",
-      Enum.map(ast.definitions, &format_definition/1),
+      Enum.map(Enum.reverse(ast.definitions), &format_definition/1),
       "end\n"
     ]
     |> IO.iodata_to_binary()

--- a/lib/gradient/debug.ex
+++ b/lib/gradient/debug.ex
@@ -84,7 +84,9 @@ defmodule Gradient.Debug do
 
   defp format_elixir_code(module, ast) do
     [
-      "defmodule ", inspect(module), " do\n",
+      "defmodule ",
+      inspect(module),
+      " do\n",
       Enum.map(ast.definitions, &format_definition/1),
       "end\n"
     ]

--- a/lib/gradient/debug.ex
+++ b/lib/gradient/debug.ex
@@ -71,6 +71,38 @@ defmodule Gradient.Debug do
     IO.puts(:erl_prettypr.format(:erl_syntax.form_list(forms)))
   end
 
+  @doc """
+  Print module as Elixir source code.
+
+  Based on https://github.com/michalmuskala/decompile by Michał Muskała
+  """
+  @spec print_elixir(module()) :: :ok
+  def print_elixir(mod) do
+    {:ok, ast} = elixir_ast(mod)
+    format_elixir_code(mod, ast)
+  end
+
+  defp format_elixir_code(module, ast) do
+    [
+      "defmodule ", inspect(module), " do\n",
+      Enum.map(ast.definitions, &format_definition/1),
+      "end\n"
+    ]
+    |> IO.iodata_to_binary()
+    |> Code.format_string!()
+    |> IO.puts()
+  end
+
+  defp format_definition({{name, _arity}, kind, _meta, heads}) do
+    Enum.map(heads, fn {_meta, args, _what?, body} ->
+      [
+        "  #{kind} #{name}(#{Enum.map_join(args, ", ", &Macro.to_string/1)}) do\n",
+        Macro.to_string(body),
+        "  end\n"
+      ]
+    end)
+  end
+
   def get_beam_path_as_charlist(mod) when is_list(mod), do: mod
   def get_beam_path_as_charlist(mod) when is_atom(mod), do: :code.which(mod)
 end


### PR DESCRIPTION
https://github.com/michalmuskala/decompile is a small repo showing how you can easily disassemble compiled BEAM bytecode into Elixir sourcecode, using the Elixir standard library. We already have `Gradient.Debug.print_erlang` which prints a compiled BEAM file as Erlang sourcecode; this adds the ability to print Elixir source code as well.