### PR TITLE
139 warn missing spec flags

### DIFF
--- a/lib/gradient/elixir_checker.ex
+++ b/lib/gradient/elixir_checker.ex
@@ -158,8 +158,11 @@ defmodule Gradient.ElixirChecker do
 
   defp warn_missing_spec(to_filter, forms) do
     all_fnas_specs =
-      forms
-      |> Enum.group_by(&elem(&1, 0), &fun_or_spec_name/1)
+      Enum.reduce(forms, %{:fun => [], :spec => []}, fn
+        {:fun, {name, _}, _}, %{fun: fnas} = acc -> %{acc | fun: [name | fnas]}
+        {:spec, {name, _}, _}, %{spec: fnas} = acc -> %{acc | spec: [name | fnas]}
+        _, acc -> acc
+      end)
 
     ret = (all_fnas_specs[:fun] -- all_fnas_specs[:spec]) -- to_filter
 
@@ -178,6 +181,4 @@ defmodule Gradient.ElixirChecker do
 
   defp exports({_, _, :export, _}), do: true
   defp exports(_), do: false
-
-  defp fun_or_spec_name({_, {name, _}, _}), do: name
 end

--- a/lib/gradient/elixir_checker.ex
+++ b/lib/gradient/elixir_checker.ex
@@ -74,6 +74,9 @@ defmodule Gradient.ElixirChecker do
         # Specs with diffrent name/arity are mixed
         {s1, [{:spec_error, :mixed_specs, anno, n, a} | errors]}
 
+      {:fun, {n, a}, anno} = fun, {{not_spec, _, _}, errors} when not_spec != :spec ->
+        {fun, [{:spec_error, :no_spec, anno, n, a} | errors]}
+
       x, {_, errors} ->
         {x, errors}
     end)

--- a/lib/gradient/elixir_checker.ex
+++ b/lib/gradient/elixir_checker.ex
@@ -165,6 +165,7 @@ defmodule Gradient.ElixirChecker do
       end)
 
     ret = (all_fnas_specs[:fun] -- all_fnas_specs[:spec]) -- to_filter
+    ret = MapSet.new(ret)
 
     Enum.reduce(forms, [], fn
       {:fun, {n, a}, anno}, acc ->

--- a/lib/gradient/elixir_fmt.ex
+++ b/lib/gradient/elixir_fmt.ex
@@ -138,6 +138,18 @@ defmodule Gradient.ElixirFmt do
     )
   end
 
+  def format_type_error({:spec_error, :no_spec, anno, name, arity}, opts) do
+    :io_lib.format(
+      "~sThe function ~p/~p~s has no spec~n",
+      [
+        format_location(anno, :brief, opts),
+        name,
+        arity,
+        format_location(anno, :verbose, opts)
+      ]
+    )
+  end
+
   def format_type_error({:call_undef, anno, module, func, arity}, opts) do
     :io_lib.format(
       "~sCall to undefined function ~s~p/~p~s~n",

--- a/lib/mix/tasks/gradient.ex
+++ b/lib/mix/tasks/gradient.ex
@@ -60,7 +60,8 @@ defmodule Mix.Tasks.Gradient do
     no_colors: :boolean,
     expr_color: :string,
     type_color: :string,
-    underscore_color: :string
+    underscore_color: :string,
+    warn_missing_spec_all: :boolean
   ]
 
   @impl Mix.Task
@@ -183,6 +184,12 @@ defmodule Mix.Tasks.Gradient do
   defp prepare_option({:no_fancy, _}, opts), do: [{:fancy, false} | opts]
 
   defp prepare_option({:stop_on_first_error, _}, opts), do: [{:crash_on_error, true} | opts]
+
+  defp prepare_option({:warn_missing_spec_all, _}, opts),
+    do: [{:warn_missing_spec, :all} | opts]
+
+  defp prepare_option({:warn_missing_spec, _}, opts),
+    do: [{:warn_missing_spec, :exported} | opts]
 
   defp prepare_option({k, v}, opts), do: [{k, v} | opts]
 

--- a/lib/mix/tasks/gradient.ex
+++ b/lib/mix/tasks/gradient.ex
@@ -61,6 +61,7 @@ defmodule Mix.Tasks.Gradient do
     expr_color: :string,
     type_color: :string,
     underscore_color: :string,
+    warn_missing_spec: :boolean,
     warn_missing_spec_all: :boolean
   ]
 
@@ -188,8 +189,9 @@ defmodule Mix.Tasks.Gradient do
   defp prepare_option({:warn_missing_spec_all, _}, opts),
     do: [{:warn_missing_spec, :all} | opts]
 
-  defp prepare_option({:warn_missing_spec, _}, opts),
-    do: [{:warn_missing_spec, :exported} | opts]
+  defp prepare_option({:warn_missing_spec, _}, opts) do
+    [{:warn_missing_spec, :exported} | opts]
+  end
 
   defp prepare_option({k, v}, opts), do: [{k, v} | opts]
 

--- a/test/examples/specs_no_specs.ex
+++ b/test/examples/specs_no_specs.ex
@@ -1,0 +1,19 @@
+defmodule SpecsNoSpecs do
+  @spec f() :: :f1_result
+  def f() do
+    f1()
+  end
+
+  def g() do
+    g1()
+  end
+
+  @spec f1() :: :f1_result
+  defp f1() do
+    :f1_result
+  end
+
+  defp g1() do
+    :g1_result
+  end
+end

--- a/test/gradient/elixir_checker_test.exs
+++ b/test/gradient/elixir_checker_test.exs
@@ -61,6 +61,21 @@ defmodule Gradient.ElixirCheckerTest do
     assert [] = ElixirChecker.check(ast, env())
   end
 
+  test "--warn-missing-spec(-all) option" do
+    ast = load("Elixir.SpecsNoSpecs.beam")
+
+    assert [] = ElixirChecker.check(ast, env())
+
+    assert [
+             {_, {:spec_error, :no_spec, 16, :g1, 0}}
+           ] = ElixirChecker.check(ast, env([], [{:warn_missing_spec, :exported}]))
+
+    assert [
+             {_, {:spec_error, :no_spec, 7, :g, 0}},
+             {_, {:spec_error, :no_spec, 16, :g1, 0}}
+           ] = ElixirChecker.check(ast, env([], [{:warn_missing_spec, :all}]))
+  end
+
   defp env(tokens \\ [], opts \\ []) do
     [{:env, Gradient.build_env(tokens)} | opts]
   end


### PR DESCRIPTION
Add flags for enabling missing specs detection:

- `--warn-missing-spec` only for the exported functions

- `--warn-missing-spec-all` for all functions