### PR TITLE
Fix invalid filepaths in umbrella

### DIFF
--- a/lib/gradient.ex
+++ b/lib/gradient.ex
@@ -66,7 +66,6 @@ defmodule Gradient do
   defp handle_elixir_ast(ast, opts) do
     ast =
       ast
-      |> put_source_path(opts)
       |> maybe_specify_forms(opts)
 
     tokens = maybe_use_tokens(ast, opts)


### PR DESCRIPTION
Solves:  [#143](https://github.com/esl/gradient/issues/143)

Bug cause:
There was double call for `put_source_path` which caused filepaths to contain duplicated entries.