### PR TITLE
[CHORE] Remove compilation warnings

### DIFF
--- a/examples/simple_phoenix_app/mix.lock
+++ b/examples/simple_phoenix_app/mix.lock
@@ -12,6 +12,7 @@
   "file_system": {:hex, :file_system, "0.2.10", "fb082005a9cd1711c05b5248710f8826b02d7d1784e7c3451f9c1231d4fc162d", [:mix], [], "hexpm", "41195edbfb562a593726eda3b3e8b103a309b733ad25f3d642ba49696bf715dc"},
   "floki": {:hex, :floki, "0.34.0", "002d0cc194b48794d74711731db004fafeb328fe676976f160685262d43706a8", [:mix], [], "hexpm", "9c3a9f43f40dde00332a589bd9d389b90c1f518aef500364d00636acc5ebc99c"},
   "gettext": {:hex, :gettext, "0.20.0", "75ad71de05f2ef56991dbae224d35c68b098dd0e26918def5bb45591d5c8d429", [:mix], [], "hexpm", "1c03b177435e93a47441d7f681a7040bd2a816ece9e2666d1c9001035121eb3d"},
+  "gradient_macros": {:git, "https://github.com/esl/gradient_macros.git", "bf5a066a6abd90cc63281d7ccb8eb7ac0fed0e64", [ref: "bf5a066"]},
   "gradualizer": {:git, "https://github.com/josefs/Gradualizer.git", "5567a232df543ce23296bd9d27a14dc81a9ff188", [ref: "5567a23"]},
   "jason": {:hex, :jason, "1.4.0", "e855647bc964a44e2f67df589ccf49105ae039d4179db7f6271dfd3843dc27e6", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "79a3791085b2a0f743ca04cec0f7be26443738779d09302e01318f97bdb82121"},
   "mime": {:hex, :mime, "2.0.3", "3676436d3d1f7b81b5a2d2bd8405f412c677558c81b1c92be58c00562bb59095", [:mix], [], "hexpm", "27a30bf0db44d25eecba73755acf4068cbfe26a4372f9eb3e4ea3a45956bff6b"},

--- a/examples/simple_umbrella_app/mix.lock
+++ b/examples/simple_umbrella_app/mix.lock
@@ -1,5 +1,4 @@
 %{
   "gradient_macros": {:git, "https://github.com/esl/gradient_macros.git", "bf5a066a6abd90cc63281d7ccb8eb7ac0fed0e64", [ref: "bf5a066"]},
-  "gradient_runtime": {:git, "https://github.com/esl/gradient_runtime.git", "ee8de905a6d262833faf84f583609aa9e79ae953", [ref: "ee8de90"]},
   "gradualizer": {:git, "https://github.com/josefs/Gradualizer.git", "5567a232df543ce23296bd9d27a14dc81a9ff188", [ref: "5567a23"]},
 }

--- a/examples/simple_umbrella_app/mix.lock
+++ b/examples/simple_umbrella_app/mix.lock
@@ -1,4 +1,5 @@
 %{
+  "gradient_macros": {:git, "https://github.com/esl/gradient_macros.git", "bf5a066a6abd90cc63281d7ccb8eb7ac0fed0e64", [ref: "bf5a066"]},
   "gradient_runtime": {:git, "https://github.com/esl/gradient_runtime.git", "ee8de905a6d262833faf84f583609aa9e79ae953", [ref: "ee8de90"]},
   "gradualizer": {:git, "https://github.com/josefs/Gradualizer.git", "5567a232df543ce23296bd9d27a14dc81a9ff188", [ref: "5567a23"]},
 }

--- a/test/examples/1.12/range_step.ex
+++ b/test/examples/1.12/range_step.ex
@@ -12,7 +12,7 @@ defmodule RangeStep do
   end
 
   def match_range do
-    first..last//step = range_step()
+    _first.._last//_step = range_step()
   end
 
   def to_list do

--- a/test/examples/call_remote_exception.ex
+++ b/test/examples/call_remote_exception.ex
@@ -1,5 +1,5 @@
 defmodule CallRemoteException do
-  def call(conn, opts) do
+  def call(_conn, _opts) do
     try do
       :ok
     rescue

--- a/test/examples/map.ex
+++ b/test/examples/map.ex
@@ -17,6 +17,6 @@ defmodule MapEx do
   end
 
   def pattern_matching_str do
-    %{"a" => a} = test_map()
+    %{"a" => _a} = test_map()
   end
 end

--- a/test/examples/record/test.ex
+++ b/test/examples/record/test.ex
@@ -27,7 +27,7 @@ defmodule Test do
   @spec f_records(record_variants()) :: :ok | :not_ok
   def f_records(r) do
     import R1
-    import R2
+    # import R2
 
     case r do
       r1(a: _) ->

--- a/test/examples/simple_app.ex
+++ b/test/examples/simple_app.ex
@@ -18,7 +18,7 @@ defmodule SimpleApp do
 
   @spec wrong_return_a(boolean()) :: integer()
   def wrong_return_a(_x) do
-    y = 12
+    _y = 12
     12
   end
 
@@ -26,7 +26,7 @@ defmodule SimpleApp do
   # def wrong_return_b(_x), do: 10
 
   @spec bool_id(boolean()) :: boolean()
-  def bool_id(x) do
+  def bool_id(_x) do
     _x = 13
     12
   end
@@ -47,5 +47,5 @@ defmodule SimpleApp do
   # bool_id(false)
   # xd = 123
   # bool_id(xd)
-  # end 
+  # end
 end

--- a/test/examples/struct/struct.ex
+++ b/test/examples/struct/struct.ex
@@ -6,14 +6,14 @@ defmodule StructEx do
   end
 
   def update do
-    %{empty | x: 13}
+    %{empty() | x: 13}
   end
 
   def get do
-    %StructEx{x: x} = update()
+    %StructEx{x: _x} = update()
   end
 
   def get2 do
-    x = update().x
+    _x = update().x
   end
 end

--- a/test/examples/try.ex
+++ b/test/examples/try.ex
@@ -8,11 +8,11 @@ defmodule Try do
       end
     rescue
       e in RuntimeError ->
-        11
+        _ = 11
         e
     catch
       val ->
-        12
+        _ = 12
         val
     end
   end
@@ -24,15 +24,15 @@ defmodule Try do
       1 / x
     rescue
       ArithmeticError ->
-        1
+        _ = 1
         :infinity
     else
       y when y < 1 and y > -1 ->
-        2
+        _ = 2
         :small
 
       _ ->
-        3
+        _ = 3
         :large
     end
   end

--- a/test/gradient/ast_specifier_test.exs
+++ b/test/gradient/ast_specifier_test.exs
@@ -691,9 +691,9 @@ defmodule Gradient.AstSpecifierTest do
                   {:map, 15,
                    [
                      {:map_field_exact, 15, {:atom, 15, :__struct__}, {:atom, 15, Range}},
-                     {:map_field_exact, 15, {:atom, 15, :first}, {:var, 15, :_first@1}},
-                     {:map_field_exact, 15, {:atom, 15, :last}, {:var, 15, :_last@1}},
-                     {:map_field_exact, 15, {:atom, 15, :step}, {:var, 15, :_step@1}}
+                     {:map_field_exact, 15, {:atom, 15, :first}, {:var, 15, :__first@1}},
+                     {:map_field_exact, 15, {:atom, 15, :last}, {:var, 15, :__last@1}},
+                     {:map_field_exact, 15, {:atom, 15, :step}, {:var, 15, :__step@1}}
                    ]}, {:call, 15, {:atom, 15, :range_step}, []}}
                ]}
             ]} = match_range
@@ -907,7 +907,7 @@ defmodule Gradient.AstSpecifierTest do
                      ],
                      [
                        {:match, 10, {:var, 10, :_e@1}, {:var, 10, :_@1}},
-                       {:integer, 11, 11},
+                       {:match, 11, {:var, 11, :_}, {:integer, 11, 11}},
                        {:var, 12, :_e@1}
                      ]},
                     {:clause, 14,
@@ -918,7 +918,8 @@ defmodule Gradient.AstSpecifierTest do
                           {:var, 14, :_val@1},
                           {:var, 14, :___STACKTRACE__@1}
                         ]}
-                     ], [], [{:integer, 15, 12}, {:var, 16, :_val@1}]}
+                     ], [],
+                     [{:match, 15, {:var, 15, :_}, {:integer, 15, 12}}, {:var, 16, :_val@1}]}
                   ], []}
                ]}
             ]} = try_rescue
@@ -936,8 +937,9 @@ defmodule Gradient.AstSpecifierTest do
                          {:op, 30, :andalso, {:op, 30, :<, {:var, 30, :_y@1}, {:integer, 30, 1}},
                           {:op, 30, :>, {:var, 30, :_y@1}, {:op, 30, :-, {:integer, 30, 1}}}}
                        ]
-                     ], [{:integer, 31, 2}, {:atom, 32, :small}]},
-                    {:clause, 34, [{:var, 34, :_}], [], [{:integer, 35, 3}, {:atom, 36, :large}]}
+                     ], [{:match, 31, {:var, 31, :_}, {:integer, 31, 2}}, {:atom, 32, :small}]},
+                    {:clause, 34, [{:var, 34, :_}], [],
+                     [{:match, 35, {:var, 35, :_}, {:integer, 35, 3}}, {:atom, 36, :large}]}
                   ],
                   [
                     {:clause, 26,
@@ -960,7 +962,7 @@ defmodule Gradient.AstSpecifierTest do
                           {:call, 26, {:remote, 26, {:atom, 26, :erlang}, {:atom, 26, :map_get}},
                            [{:atom, 26, :__exception__}, {:var, 26, :_@1}]}}
                        ]
-                     ], [{:integer, 27, 1}, {:atom, 28, :infinity}]}
+                     ], [{:match, 27, {:var, 27, :_}, {:integer, 27, 1}}, {:atom, 28, :infinity}]}
                   ], []}
                ]}
             ]} = try_else
@@ -1087,7 +1089,7 @@ defmodule Gradient.AstSpecifierTest do
                    [
                      {:map_field_exact, 20,
                       {:bin, 20, [{:bin_element, 20, {:string, 20, 'a'}, :default, :default}]},
-                      {:var, 20, :_a@1}}
+                      {:var, 20, :__a@1}}
                    ]}, {:call, 20, {:atom, 20, :test_map}, []}}
                ]}
             ]} = pattern_matching_str
@@ -1114,7 +1116,7 @@ defmodule Gradient.AstSpecifierTest do
             [
               {:clause, 16, [], [],
                [
-                 {:match, 17, {:var, 17, :_x@1},
+                 {:match, 17, {:var, 17, :__x@1},
                   {:case, [generated: true, location: 17], {:call, 17, {:atom, 17, :update}, []},
                    [
                      {:clause, [generated: true, location: 17],
@@ -1164,7 +1166,7 @@ defmodule Gradient.AstSpecifierTest do
                   {:map, 13,
                    [
                      {:map_field_exact, 13, {:atom, 13, :__struct__}, {:atom, 13, StructEx}},
-                     {:map_field_exact, 13, {:atom, 13, :x}, {:var, 13, :_x@1}}
+                     {:map_field_exact, 13, {:atom, 13, :x}, {:var, 13, :__x@1}}
                    ]}, {:call, 13, {:atom, 13, :update}, []}}
                ]}
             ]} = get

--- a/test/gradient/elixir_fmt_test.exs
+++ b/test/gradient/elixir_fmt_test.exs
@@ -21,7 +21,7 @@ defmodule Gradient.ElixirFmtTest do
     res = ElixirFmt.try_highlight_in_context(expression, opts)
 
     expected =
-      {:ok, "29   def bool_id(x) do\n30     _x = 13\n\e[4m\e[31m31     12\e[0m\n32   end\n33 "}
+      {:ok, "29   def bool_id(_x) do\n30     _x = 13\n\e[4m\e[31m31     12\e[0m\n32   end\n33 "}
 
     assert res == expected
   end


### PR DESCRIPTION
Remove some of the compilation warnings we get from `test/examples` 

I have resolved most of the compilation warnings we get from GH Actions Annotations
and almost all we get from recompiling `test/examples` directory the ones left are:

- `Plug.Conn.WrapperError.reraise/1 is undefined (module Plug.Conn.WrapperError is not available or is yet to be defined)`
- `Sentry.capture_message/2 is undefined (module Sentry is not available or is yet to be defined)`
