### PR TITLE
Improve Elixir decompilation, add tests for Gradient.Debug module

### DIFF
--- a/examples/simple_phoenix_app/mix.lock
+++ b/examples/simple_phoenix_app/mix.lock
@@ -12,7 +12,7 @@
   "file_system": {:hex, :file_system, "0.2.10", "fb082005a9cd1711c05b5248710f8826b02d7d1784e7c3451f9c1231d4fc162d", [:mix], [], "hexpm", "41195edbfb562a593726eda3b3e8b103a309b733ad25f3d642ba49696bf715dc"},
   "floki": {:hex, :floki, "0.34.0", "002d0cc194b48794d74711731db004fafeb328fe676976f160685262d43706a8", [:mix], [], "hexpm", "9c3a9f43f40dde00332a589bd9d389b90c1f518aef500364d00636acc5ebc99c"},
   "gettext": {:hex, :gettext, "0.20.0", "75ad71de05f2ef56991dbae224d35c68b098dd0e26918def5bb45591d5c8d429", [:mix], [], "hexpm", "1c03b177435e93a47441d7f681a7040bd2a816ece9e2666d1c9001035121eb3d"},
-  "gradient_macros": {:git, "https://github.com/esl/gradient_macros.git", "bf5a066a6abd90cc63281d7ccb8eb7ac0fed0e64", [ref: "bf5a066"]},
+  "gradient_macros": {:git, "https://github.com/esl/gradient_macros.git", "3bce2146bf0cdf380f773c40e2b7bd6558ab6de8", [ref: "3bce214"]},
   "gradualizer": {:git, "https://github.com/josefs/Gradualizer.git", "1498d1792155010950c86dc3e92ccb111b706e80", [ref: "1498d17"]},
   "jason": {:hex, :jason, "1.4.0", "e855647bc964a44e2f67df589ccf49105ae039d4179db7f6271dfd3843dc27e6", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "79a3791085b2a0f743ca04cec0f7be26443738779d09302e01318f97bdb82121"},
   "mime": {:hex, :mime, "2.0.3", "3676436d3d1f7b81b5a2d2bd8405f412c677558c81b1c92be58c00562bb59095", [:mix], [], "hexpm", "27a30bf0db44d25eecba73755acf4068cbfe26a4372f9eb3e4ea3a45956bff6b"},

--- a/examples/simple_umbrella_app/mix.lock
+++ b/examples/simple_umbrella_app/mix.lock
@@ -1,4 +1,4 @@
 %{
-  "gradient_macros": {:git, "https://github.com/esl/gradient_macros.git", "bf5a066a6abd90cc63281d7ccb8eb7ac0fed0e64", [ref: "bf5a066"]},
+  "gradient_macros": {:git, "https://github.com/esl/gradient_macros.git", "3bce2146bf0cdf380f773c40e2b7bd6558ab6de8", [ref: "3bce214"]},
   "gradualizer": {:git, "https://github.com/josefs/Gradualizer.git", "1498d1792155010950c86dc3e92ccb111b706e80", [ref: "1498d17"]},
 }

--- a/lib/gradient/debug.ex
+++ b/lib/gradient/debug.ex
@@ -3,6 +3,8 @@ defmodule Gradient.Debug do
   Helpers for convenient debugging Erlang and Elixir ASTs.
   """
 
+  alias Gradient.ElixirType
+
   ## TODO: specify elixir_form
   @type elixir_form() :: any()
   @type erlang_form() :: Gradient.Types.form()
@@ -79,15 +81,50 @@ defmodule Gradient.Debug do
   @spec print_elixir(module()) :: :ok
   def print_elixir(mod) do
     {:ok, ast} = elixir_ast(mod)
-    format_elixir_code(mod, ast)
+    {:ok, forms} = erlang_ast(mod)
+
+    format_elixir_code(mod, ast, forms)
   end
 
-  defp format_elixir_code(module, ast) do
+  defp format_elixir_code(module, ast, forms) do
+    specs =
+      forms
+      |> Enum.filter(&match?({:attribute, _line, :spec, _contents}, &1))
+      |> Enum.map(fn {:attribute, _line, :spec, {{_fun, _arity} = fun_arity, types}} ->
+        {fun_arity, types}
+      end)
+      |> Enum.into(%{})
+
+    # Function definitions
+    definitions =
+      ast.definitions
+      |> Enum.reverse()
+      |> Enum.map(fn {{name, arity}, kind, _meta, heads} ->
+        spec = Map.get(specs, {name, arity})
+
+        %{
+          name: name,
+          kind: kind,
+          heads: heads,
+          spec: spec
+        }
+      end)
+      |> Enum.map(&format_definition/1)
+
+    # Types
+    types =
+      forms
+      |> Enum.filter(&match?({:attribute, _line, :type, _contents}, &1))
+      |> Enum.map(fn {:attribute, _line, :type, {type_name, type, _}} ->
+        "@type #{type_name} :: #{Gradient.ElixirType.pretty_print(type)}\n"
+      end)
+
     [
       "defmodule ",
       inspect(module),
       " do\n",
-      Enum.map(Enum.reverse(ast.definitions), &format_definition/1),
+      types,
+      definitions,
       "end\n"
     ]
     |> IO.iodata_to_binary()
@@ -95,21 +132,47 @@ defmodule Gradient.Debug do
     |> IO.puts()
   end
 
-  defp format_definition({{name, _arity}, kind, _meta, heads}) do
+  defp format_definition(%{name: name, kind: kind, heads: heads, spec: spec}) do
     # Replace unallowed characters in function names with `_`.
     #
     # This is for cases where the name is like "call (overridable 2)", in which
     # case it'd get converted to "call__overridable_2_".
     name = Regex.replace(~r/[^\w\?\!]/, to_string(name), "_")
 
-    Enum.map(heads, fn {_meta, args, _what?, body} ->
-      [
-        "  #{kind} #{name}(#{Enum.map_join(args, ", ", &Macro.to_string/1)}) do\n    ",
-        Macro.to_string(body),
-        "\n  end\n\n"
-      ]
-    end)
+    formatted_def =
+      Enum.map(heads, fn {_meta, args, _what?, body} ->
+        [
+          "  #{kind} #{name}(#{Enum.map_join(args, ", ", &Macro.to_string/1)}) do\n    ",
+          Macro.to_string(body),
+          "\n  end\n\n"
+        ]
+      end)
+
+    formatted_spec =
+      if spec do
+        Enum.map(spec, &"@spec #{print_spec(name, &1)}\n")
+      else
+        []
+      end
+
+    formatted_spec ++ formatted_def
   end
+
+  # Modified version of Gradient.ElixirType.pretty_print(), for function specs
+  # rather than anonymous functions
+  defp print_spec(name, {:type, _, :fun, [args, res_type]} = _spec) do
+    args = print_spec_args(args)
+    res = ElixirType.pretty_print(res_type)
+    "#{name}(#{args}) :: #{res}"
+  end
+
+  defp print_spec_args({:type, _, :product, arg_types}) do
+    arg_types
+    |> Enum.map(&ElixirType.pretty_print(&1))
+    |> Enum.join(", ")
+  end
+
+  defp print_spec_args({:type, _, :any}), do: "..."
 
   def get_beam_path_as_charlist(mod) when is_list(mod), do: mod
   def get_beam_path_as_charlist(mod) when is_atom(mod), do: :code.which(mod)

--- a/test/gradient/debug_test.exs
+++ b/test/gradient/debug_test.exs
@@ -1,0 +1,112 @@
+defmodule Gradient.DebugTest do
+  use ExUnit.Case
+
+  alias Gradient.Debug
+  import ExUnit.CaptureIO
+
+  @examples_build_path "test/examples/_build"
+
+  defp build_beam_path(beam_file) do
+    @examples_build_path
+    |> Path.join(beam_file)
+    |> String.to_charlist()
+  end
+
+  describe "elixir_ast/1" do
+    test "returns elixir AST" do
+      beam_path = build_beam_path("Elixir.Basic.beam")
+
+      assert {:ok,
+              %{
+                attributes: [],
+                compile_opts: [],
+                definitions: [
+                  {{:string, 0}, :def, [line: 4], [{[line: 4], [], [], "2"}]},
+                  {{:int, 0}, :def, [line: 2], [{[line: 2], [], [], 1}]},
+                  {{:float, 0}, :def, [line: 3], [{[line: 3], [], [], 1.5}]},
+                  {{:charlist, 0}, :def, [line: 5], [{[line: 5], [], [], '3'}]},
+                  {{:char, 0}, :def, [line: 6], [{[line: 6], [], [], 99}]}
+                ],
+                deprecated: [],
+                file: _file,
+                is_behaviour: false,
+                line: 1,
+                module: Basic,
+                relative_file: "test/examples/basic.ex",
+                struct: nil,
+                unreachable: []
+              }} = Debug.elixir_ast(beam_path)
+    end
+  end
+
+  describe "erlang_ast/1" do
+    test "returns erlang AST" do
+      beam_path = build_beam_path("Elixir.Basic.beam")
+
+      assert {:ok, forms} = Debug.erlang_ast(beam_path)
+
+      function_defs =
+        forms
+        |> Enum.filter(&(elem(&1, 0) == :function))
+        |> Enum.reject(&(elem(&1, 2) == :__info__))
+        |> Enum.sort_by(fn {:function, line, _, _, _} -> line end)
+
+      assert function_defs ==
+               [
+                 {:function, 2, :int, 0, [{:clause, 2, [], [], [{:integer, 2, 1}]}]},
+                 {:function, 3, :float, 0, [{:clause, 3, [], [], [{:float, 3, 1.5}]}]},
+                 {:function, 4, :string, 0,
+                  [
+                    {:clause, 4, [], [],
+                     [{:bin, 4, [{:bin_element, 4, {:string, 4, '2'}, :default, :default}]}]}
+                  ]},
+                 {:function, 5, :charlist, 0,
+                  [{:clause, 5, [], [], [{:cons, 5, {:integer, 5, 51}, {nil, 5}}]}]},
+                 {:function, 6, :char, 0, [{:clause, 6, [], [], [{:integer, 6, 99}]}]}
+               ]
+    end
+  end
+
+  describe "print_erlang/1" do
+    test "prints erlang representation of module" do
+      beam_path = build_beam_path("Elixir.Basic.beam")
+
+      output_lines =
+        capture_io(fn -> Debug.print_erlang(beam_path) end)
+        |> String.split("\n")
+
+      assert "-file(\"test/examples/basic.ex\", 1)." in output_lines
+      assert "-module('Elixir.Basic')." in output_lines
+      assert "char() -> 99." in output_lines
+      assert "int() -> 1." in output_lines
+    end
+  end
+
+  describe "print_elixir/1" do
+    test "prints elixir specs and functions" do
+      beam_path = build_beam_path("Elixir.SWrongRet.beam")
+
+      output_lines =
+        capture_io(fn -> Debug.print_elixir(beam_path) end)
+        |> String.split("\n")
+        |> Enum.map(&String.trim/1)
+
+      assert "@spec ret_wrong_atom() :: atom()" in output_lines
+      assert "def ret_wrong_atom() do" in output_lines
+
+      assert "@spec ret_wrong_atom2() :: atom()" in output_lines
+      assert "def ret_wrong_atom2() do" in output_lines
+    end
+
+    test "prints elixir types" do
+      beam_path = build_beam_path("Elixir.Typespec.beam")
+
+      output_lines =
+        capture_io(fn -> Debug.print_elixir(beam_path) end)
+        |> String.split("\n")
+        |> Enum.map(&String.trim/1)
+
+      assert "@type mylist :: list(t)" in output_lines
+    end
+  end
+end

--- a/test/gradient/debug_test.exs
+++ b/test/gradient/debug_test.exs
@@ -51,19 +51,18 @@ defmodule Gradient.DebugTest do
         |> Enum.reject(&(elem(&1, 2) == :__info__))
         |> Enum.sort_by(fn {:function, line, _, _, _} -> line end)
 
-      assert function_defs ==
-               [
-                 {:function, 2, :int, 0, [{:clause, 2, [], [], [{:integer, 2, 1}]}]},
-                 {:function, 3, :float, 0, [{:clause, 3, [], [], [{:float, 3, 1.5}]}]},
-                 {:function, 4, :string, 0,
-                  [
-                    {:clause, 4, [], [],
-                     [{:bin, 4, [{:bin_element, 4, {:string, 4, '2'}, :default, :default}]}]}
-                  ]},
-                 {:function, 5, :charlist, 0,
-                  [{:clause, 5, [], [], [{:cons, 5, {:integer, 5, 51}, {nil, 5}}]}]},
-                 {:function, 6, :char, 0, [{:clause, 6, [], [], [{:integer, 6, 99}]}]}
-               ]
+      assert [
+               {:function, 2, :int, 0, [{:clause, 2, [], [], [{:integer, _, 1}]}]},
+               {:function, 3, :float, 0, [{:clause, 3, [], [], [{:float, _, 1.5}]}]},
+               {:function, 4, :string, 0,
+                [
+                  {:clause, 4, [], [],
+                   [{:bin, _, [{:bin_element, _, {:string, _, '2'}, :default, :default}]}]}
+                ]},
+               {:function, 5, :charlist, 0,
+                [{:clause, _, [], [], [{:cons, _, {:integer, _, 51}, {nil, _}}]}]},
+               {:function, 6, :char, 0, [{:clause, _, [], [], [{:integer, _, 99}]}]}
+             ] = function_defs
     end
   end
 


### PR DESCRIPTION
Improves Elixir decompilation in the Gradient.Debug module:
- outputs function specs
- outputs defined types
Previously, `Gradient.Debug.print_elixir` would only print function definitions. Also printing out specs and types defined in the module will help with debugging Gradient-related issues with compiled Elixir code.

Also adds some basic unit tests for the Gradient.Debug module.

Note: This was initially developed as part of another PR https://github.com/esl/gradient/pull/167. However, the main point of that PR was to provide a (failing) test case for issue https://github.com/esl/gradient/issues/168. I don't expect that PR to be merged, but I felt this extra debugging code was worth merging as a separate PR.