### PR TITLE
Add additional kinds

### DIFF
--- a/lib/gradient/error.ex
+++ b/lib/gradient/error.ex
@@ -70,6 +70,7 @@ defmodule Gradient.Error do
           | :relop
           | :unary_error
           | :unreachable_clause
+          | :unreachable_clauses
 
   @type undef_kind ::
           :record
@@ -238,6 +239,10 @@ defmodule Gradient.Error do
     {:type_error, :call_intersect}
   end
 
+  def kind({:type_error, :call_intersect, _anno, _fun_ty, _name, _ty}) do
+    {:type_error, :call_intersect}
+  end
+
   def kind({:type_error, :cyclic_type_vars, _anno, _ty, _xs}) do
     {:type_error, :cyclic_type_vars}
   end
@@ -312,6 +317,10 @@ defmodule Gradient.Error do
 
   def kind({:type_error, :unreachable_clause, _anno}) do
     {:type_error, :unreachable_clause}
+  end
+
+  def kind({:type_error, :unreachable_clauses, _anno}) do
+    {:type_error, :unreachable_clauses}
   end
 
   def kind({:type_error, a, b, c})

--- a/lib/gradient/error.ex
+++ b/lib/gradient/error.ex
@@ -314,10 +314,6 @@ defmodule Gradient.Error do
     {:type_error, :unary_error}
   end
 
-  def kind({:type_error, :unreachable_clause, _anno}) do
-    {:type_error, :unreachable_clause}
-  end
-
   def kind({:type_error, :unreachable_clauses, _anno}) do
     {:type_error, :unreachable_clauses}
   end

--- a/lib/gradient/error.ex
+++ b/lib/gradient/error.ex
@@ -69,7 +69,6 @@ defmodule Gradient.Error do
           | :rel_error
           | :relop
           | :unary_error
-          | :unreachable_clause
           | :unreachable_clauses
 
   @type undef_kind ::


### PR DESCRIPTION
To resolve these debug warnings

```elixir
11:50:18.726 [debug] Could not determine kind of error: {:type_error, :unreachable_clauses, 26}

11:50:20.408 [debug] Could not determine kind of error: {:type_error, :call_intersect, 390, {:remote, 390, {:atom, 390, List}, {:atom, 390, :first}}, [{:type, 0, :bounded_fun, [{:type, 0, :fun, [{:type, 0, :product, [{:type, 0, nil, []}, {:type, 0, :any, []}]}, {:type, 0, :any, []}]}, []]}, {:type, 0, :bounded_fun, [{:type, 0, :fun, [{:type, 0, :product, [{:type, 0, :nonempty_list, [{:var, 0, :elem}]}, {:type, 0, :any, []}]}, {:var, 0, :elem}]}, []]}], [{:type, 0, :list, []}, {:type, 0, :tuple, [{:atom, 0, nil}, {:atom, 0, nil}]}]}
```

I'm working on a huge codebase that (mostly) passes Dialyzer but gets lots of exciting warnings from Gradient 